### PR TITLE
Hide the next and the previous button on each page

### DIFF
--- a/docs/css/fastlane.css
+++ b/docs/css/fastlane.css
@@ -28,6 +28,11 @@ h3, h4, h5, h6 {
   display: none !important; 
 }
 
+/* The next and previous button we don't need */
+.rst-footer-buttons {
+  display: none;
+}
+
 
 /*
   So here is the deal:


### PR DESCRIPTION
These buttons just don't make a lot of sense for our use-case, as it's not really gradual. This PR hides the 2 buttons.

---

**Before**
<img width="1361" alt="screenshot 2016-08-25 18 17 44" src="https://cloud.githubusercontent.com/assets/869950/17991044/3b261244-6af0-11e6-86d8-c8a367ecee63.png">

----

**After**
<img width="868" alt="screenshot 2016-08-25 18 18 48" src="https://cloud.githubusercontent.com/assets/869950/17991074/672c5b5a-6af0-11e6-81dd-960c3a8ecabe.png">