### PR TITLE
Use Python 2.7.11 instead of PyPy 2.2.1.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   python:
-    version: pypy-2.2.1
+    version: 2.7.11
   ruby:
     version: 2.3.0
 dependencies:


### PR DESCRIPTION
[PyPy 2.2.1 targets Python 2.7.3](http://doc.pypy.org/en/latest/release-2.2.1.html).

This change shouldn't make a difference in production since we only use Python to build the static site, but more people will already have CPython installed locally to develop. Python 2.7.11 is the latest Python 2.7 release.