### PR TITLE
Specify dependencies in requirements.txt.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fastlane docs
 
-This repo contains all documentation for fastlane. You can find the `.md` files inside the [docs](docs) folder. 
+This repo contains all documentation for fastlane. You can find the `.md` files inside the [docs](docs) folder.
 
 To preview the updated documentation locally, just clone the repo, modify the file, and run
 
@@ -16,5 +16,23 @@ Once a PR is merged into master, the latest version will automatically be deploy
 
 ```sh
 brew install python # if you don't have pip already
-[sudo] pip install mkdocs pymdown-extensions
+[sudo] pip install -r requirements.txt
 ```
+
+## Adding a Python dependency
+
+Likely, to add a [Markdown extension](https://pythonhosted.org/Markdown/extensions/).
+
+1. Install with `pip install <some extension>`
+2. Add <some extension> to [requirements-to-freeze.txt](requirements-to-freeze.txt).
+3. Run `pip freeze > requirements.txt` to update the exact requirements.
+
+### Why requirements-to-freeze.txt?
+
+Based on [A Better Pip Workflow](http://www.kennethreitz.org/essays/a-better-pip-workflow),
+`requirements-to-freeze.txt` and `requirements.txt` provide a similar experience
+to Gemfile and Gemfile.lock, respectively.
+
+`requirements-to-freeze.txt` lets you pick out the top level packages the
+project depends on, while `requirements.txt` exactly specifies all of the
+dependencies and subdependencies for repeatable builds.

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ machine:
     version: 2.3.0
 dependencies:
   pre:
-    - pip install mkdocs pymdown-extensions
+    - pip install -r requirements.txt
 test:
   override:
     - bundle exec fastlane test

--- a/requirements-to-freeze.txt
+++ b/requirements-to-freeze.txt
@@ -1,0 +1,2 @@
+mkdocs
+pymdown-extensions

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,15 @@
+backports-abc==0.4
+certifi==2016.8.8
+click==6.6
+Jinja2==2.8
+livereload==2.4.1
+Markdown==2.6.6
+MarkupSafe==0.23
+mkdocs==0.15.3
+mkdocs-bootstrap==0.1.1
+mkdocs-bootswatch==0.4.0
+pymdown-extensions==1.1
+PyYAML==3.12
+singledispatch==3.4.0.3
+six==1.10.0
+tornado==4.4.1


### PR DESCRIPTION
Having a [requirements.txt](https://pip.readthedocs.io/en/1.1/requirements.html) makes it easier to add markdown extensions (or any Python dependency), since developers can always run the same `pip install -r requirements.txt` to install the dependency locally and the [CI install command](https://github.com/fastlane/docs/blob/ae7b6a3630dce01f7ad06d7a35e9a79371bee2b6/circle.yml#L8) doesn't have to change whenever a dependency does.

The `requirements-to-freeze.txt` and `requirements.txt` setup comes from [A Better Pip Workflow](http://www.kennethreitz.org/essays/a-better-pip-workflow). I haven't used it before, but it sounds intriguing and I've been interested in giving it a try, since there isn't a good supported format like a `Gemfile.lock` or `npm-shrinkwrap.json`.