### PR TITLE
Extend toc.html to remove unwanted <li>s in the build.

### DIFF
--- a/docs/css/fastlane.css
+++ b/docs/css/fastlane.css
@@ -25,7 +25,7 @@ h3, h4, h5, h6 {
 }
 
 .rst-versions {
-  display: none !important; 
+  display: none !important;
 }
 
 /* The next and previous button we don't need */
@@ -44,28 +44,8 @@ details > summary {
   cursor: pointer
 }
 
-
-/*
-  So here is the deal:
-    - We don't want h2 tags to be shown in the sidebar, as it's too cluttered
-    - However we still want h1 tag in the sidebar, except for the first one
-      The reason for that, is that the first h1 is usually just the page name
-      This way, you can still have links in the sidebar without cluttering it 
-      too much by having multiple h1 tags
-*/
-
-/* Hide all h2 tags */
-.toctree-l4 {
-  display: none !important;
-}
-
-/* Hide the first h1 tag in the sidebar*/
-.toctree-l3:first-child {
-  display: none !important;
-}
-
 /* Fix the design not having the correct spacing */
-.wy-menu-vertical li.current > a {
+.wy-menu-vertical .subnav li.current > a {
   padding: 0.4045em 2.427em;
 }
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ google_analytics: ["UA-18658848-13", "docs.fastlane.tools"]
 # strict: true # TODO: Enable once we have the docs structure
 markdown_extensions:
   - pymdownx.headeranchor
+theme_dir: theme
 
 pages:
 - Home: index.md

--- a/theme/toc.html
+++ b/theme/toc.html
@@ -1,0 +1,21 @@
+{% if nav_item.children %}
+<ul class="subnav">
+  <li><span>{{ nav_item.title }}</span></li>
+  {% for nav_item in nav_item.children %}
+  {% include 'toc.html' %}
+  {% endfor %}
+</ul>
+{% else %}
+<li class="toctree-l1 {% if nav_item.active%}current{%endif%}">
+  <a class="{% if nav_item.active%}current{%endif%}" href="{{ nav_item.url }}">{{ nav_item.title }}</a>
+  {% if nav_item == current_page %}
+  <ul>
+    {% for toc_item in toc %}
+      {% if loop.index != 1 %}
+      <li class="toctree-l3"><a href="{{ toc_item.url }}">{{ toc_item.title }}</a></li>
+      {% endif %}
+    {% endfor %}
+  </ul>
+  {% endif %}
+</li>
+{% endif %}


### PR DESCRIPTION
Also fix top level toc items having too much padding when active. First item on #42.

Before: (from docs.fastlane.tools)

![screen shot 2016-08-29 at 10 34 23 pm](https://cloud.githubusercontent.com/assets/3270544/18077199/cab5c04e-6e38-11e6-8ffa-a290c3d45ec6.png)

After: Only visible change is no extra padding for top level active navigation items (like "Home").

![screen shot 2016-08-29 at 10 34 03 pm](https://cloud.githubusercontent.com/assets/3270544/18077202/cbd976aa-6e38-11e6-9ad3-45e48c75f656.png)