### PR TITLE
Temporarly remove beta deployment, as guide is not finished yet

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,7 +21,6 @@ pages:
   - Android:
     - Setup: getting-started/android/setup.md
     - Screenshots: getting-started/android/screenshots.md
-    - Beta Deployment: getting-started/android/beta-deployment.md
     - Release Deployment: getting-started/android/release-deployment.md
 - Actions: actions/Actions.md
 - FAQs: FAQs.md


### PR DESCRIPTION
We should still write this guide, which should contain third party beta testing services, but since we’re launching the site today, we’ll have this item removed for now