### PR TITLE
Remove dead link to beta distributions

### DIFF
--- a/docs/getting-started/android/setup.md
+++ b/docs/getting-started/android/setup.md
@@ -81,7 +81,6 @@ Due to limitations of the Google Play API, _supply_ can't download existing scre
 _fastlane_ is ready to generate screenshots and automatically distribute new builds! To learn more, check out:
 
 - [Automatically generate screenshots](screenshots.md)
-- [Distribute beta builds](beta-deployment.md)
 - [Deploy to Google Play for production release](release-deployment.md)
 
 ### Use a Gemfile


### PR DESCRIPTION
Link points to https://docs.fastlane.tools/getting-started/android/setup/beta-deployment.md which doesn't exist.

Like: https://github.com/fastlane/docs/commit/95b56163d5d013f4401b745eb4c5240fa43e2762

Dead link was found by an Android community member!