### PR TITLE
Fix site_favicon key in mkdocs.yml.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ theme: readthedocs
 copyright: Copyright &copy; 2016 <a href="https://fastlane.tools">fastlane</a>
 site_author: "fastlane team"
 site_description: "Documentation for fastlane tools, the easiest way to automate building and releasing your iOS and Android apps"
-favicon: "img/favicon.ico"
+site_favicon: "img/favicon.ico"
 google_analytics: ["UA-18658848-13", "docs.fastlane.tools"]
 # strict: true # TODO: Enable once we have the docs structure
 markdown_extensions:


### PR DESCRIPTION
Use the correct [config key](http://mkdocs.readthedocs.io/en/0.15.3/user-guide/configuration/#site_favicon) (and gets rid of the warning when building).

```
WARNING -  Config value: 'favicon'. Warning: Unrecognised configuration name: favicon
```