### PR TITLE
Add space to 'Available Plugins' in the ToC.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,7 +30,7 @@ pages:
   - Troubleshooting: codesigning/Troubleshooting.md
   - Common Issues: codesigning/CommonIssues.md
 - Plugins:
-  - AvailablePlugins: plugins/AvailablePlugins.md
+  - Available Plugins: plugins/AvailablePlugins.md
   - Create your own plugin: plugins/CreatePlugin.md
   - Plugins Troubleshooting: plugins/PluginsTroubleshooting.md
 - Best Practices:


### PR DESCRIPTION
"Available Plugins" in the sidebar ToC was missing a space.