### PR TITLE
Maintain normal badge size on mobile.

### DIFF
--- a/docs/css/fastlane.css
+++ b/docs/css/fastlane.css
@@ -167,3 +167,10 @@ footer .fastlane iframe {
 .rst-content .headeranchor:before {
   content: '\f0c1';
 }
+
+/* index.md badges */
+@media screen and (max-width: 768px) {
+  .badge img {
+    width: auto;
+  }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,9 +3,9 @@
 fastlane
 ============
 
-[![Twitter: @Fastlane1ols](https://img.shields.io/badge/contact-@FastlaneTools-blue.svg?style=flat)](https://twitter.com/FastlaneTools)
-[![License](https://img.shields.io/badge/license-MIT-green.svg?style=flat)](https://github.com/fastlane/fastlane/blob/master/LICENSE)
-[![Gem](https://img.shields.io/gem/v/fastlane.svg?style=flat)](http://rubygems.org/gems/fastlane)
+[![Twitter: @Fastlane1ols](https://img.shields.io/badge/contact-@FastlaneTools-blue.svg?style=flat)](https://twitter.com/FastlaneTools){: .badge }
+[![License](https://img.shields.io/badge/license-MIT-green.svg?style=flat)](https://github.com/fastlane/fastlane/blob/master/LICENSE){: .badge }
+[![Gem](https://img.shields.io/gem/v/fastlane.svg?style=flat)](http://rubygems.org/gems/fastlane){: .badge }
 
 _fastlane_ is **the** tool to release your iOS and Android app 🚀 It handles all tedious tasks, like generating screenshots, dealing with code signing, and releasing your application.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ google_analytics: ["UA-18658848-13", "docs.fastlane.tools"]
 # strict: true # TODO: Enable once we have the docs structure
 markdown_extensions:
   - pymdownx.headeranchor
+  - markdown.extensions.attr_list
 theme_dir: theme
 
 pages:


### PR DESCRIPTION
Currently the badges appear at 100% width on mobile. They should stay the same size.

#42:

> The page should render nicely on mobile too. Currently some images, e.g. the badges are rendered 100% width

![screen shot 2016-09-06 at 2 50 56 pm](https://cloud.githubusercontent.com/assets/3270544/18286614/9c8dedfe-7441-11e6-8756-d2215ea5abdd.png)
