### PR TITLE
Add ‘where to go from here’ to code signing docs

### DIFF
--- a/docs/codesigning/GettingStarted.md
+++ b/docs/codesigning/GettingStarted.md
@@ -67,3 +67,10 @@ Apple improved code signing a lot with the release of Xcode 8, the following has
 You can always manually create and manage your certificates and provisioning profiles using the Apple Developer Portal. Make sure to store the private key (`.p12`) of your certificates in a safe place, as they can't be restored if you lose them. 
 
 You can always download the certificate (`.cer`) and provisioning profile (`.mobileprovision`) from the Apple Developer Portal.
+
+## Where to go from here
+
+- [Setting up your Xcode Project](XcodeProject.md)
+- [Troubleshooting code signing errors](Troubleshooting.md)
+- [Common Issues](CommonIssues.md)
+- [Upgrading to Xcode 8](XcodeProject.md#xcode-8-and-up)


### PR DESCRIPTION
<img width="822" alt="screenshot 2016-09-22 14 01 42" src="https://cloud.githubusercontent.com/assets/869950/18760019/33f10f0e-80cd-11e6-8219-a944bc225e3f.png">

to https://docs.fastlane.tools/codesigning/GettingStarted/