### PR TITLE
Fix typo in Crashlytics beta deployment information

### DIFF
--- a/docs/getting-started/ios/beta-deployment.md
+++ b/docs/getting-started/ios/beta-deployment.md
@@ -113,7 +113,7 @@ To get your API token, open the [organizations settings page](https://www.fabric
 To get a list of all available options, run
 
 ```no-highlight
-fastlane action testfairy
+fastlane action crashlytics
 ```
 
 TODO: Also mention the other onboarding method


### PR DESCRIPTION
Looks like there was a small typo in the Crashlytics deployment section, where it referenced testfairy in the code snippet to show available options.