### PR TITLE
Add LICENSE link to contributing page

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -181,6 +181,6 @@ Help us keep _fastlane_ open and inclusive. Please read and follow our [Code of 
 Thank you for reading to the end, and for taking the time to contribute to the project! If you include the 🔑 emoji at the top of the body of your issue or pull request, we'll know that you've given this your full attention and are doing your best to help!
 
 ## License
-This project is licensed under the terms of the MIT license. See the LICENSE file.
+This project is licensed under the terms of the MIT license. See the [LICENSE](https://github.com/fastlane/fastlane/blob/master/LICENSE) file.
 
 > This project and all fastlane tools are in no way affiliated with Apple Inc. This project is open source under the MIT license, which means you have full access to the source code and can modify it to fit your own needs. All fastlane tools run on your own computer or server, so your credentials or other sensitive information will never leave your own computer. You are responsible for how you use fastlane tools.

--- a/docs/index.md
+++ b/docs/index.md
@@ -102,6 +102,6 @@ _fastlane_ requires macOS or Linux with Ruby 2.0.0 or above
 
 ## License
 
-This project is licensed under the terms of the MIT license. See the [LICENSE](LICENSE) file.
+This project is licensed under the terms of the MIT license. See the [LICENSE](https://github.com/fastlane/fastlane/blob/master/LICENSE) file.
 
 > This project and all fastlane tools are in no way affiliated with Apple Inc or Google. This project is open source under the MIT license, which means you have full access to the source code and can modify it to fit your own needs. All fastlane tools run on your own computer or server, so your credentials or other sensitive information will never leave your own computer. You are responsible for how you use fastlane tools.


### PR DESCRIPTION
Previously, the bottom of the document just showed LICENSE as text, so this adds a link.

PS - I'm new to github and PRs, hope I did this correctly...