### PR TITLE
Fix plugins section anchor link

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -28,7 +28,7 @@ import './path/to/other/Fastfile'
 - [Notifications](#notifications)
 - [Deprecated](#deprecated)
 - [Misc](#misc)
-- [Plugins](#Plugins)
+- [Plugins](#plugins)
 
 
 


### PR DESCRIPTION
This is a small change, but it fixes navigation error on plugin section due to capitalized anchor link.