### PR TITLE
Update deploy script to clean git repo before running `git checkout`

### DIFF
--- a/scripts/ci/deploy.sh
+++ b/scripts/ci/deploy.sh
@@ -23,6 +23,7 @@ cp "scripts/ci/generate_redirects.rb" "/tmp/"
 # Clean all temporary files (e.g. .bundle/config and .ruby-version)
 git clean -f -d
 # Check out gh-pages and clear all files
+git reset --hard HEAD # we don't want the `git checkout` to cause issues (e.g. https://circleci.com/gh/fastlane/docs/730)
 git checkout gh-pages
 rm -rf *
 # Copy the finished HTML page to the current directory


### PR DESCRIPTION
This should fix failures like https://circleci.com/gh/fastlane/docs/730