### PR TITLE
Remove case-only redirects

### DIFF
--- a/scripts/ci/available_redirects.rb
+++ b/scripts/ci/available_redirects.rb
@@ -1,19 +1,14 @@
-def docs_redirects 
+def docs_redirects
   {
     "codesigning/GettingStarted" => "codesigning/getting-started",
     "codesigning/XcodeProject/" => "/codesigning/xcode-project/",
-    "codesigning/Troubleshooting/" => "/codesigning/troubleshooting/",
     "codesigning/CommonIssues" => "codesigning/common-issues",
     "plugins/AvailablePlugins" => "plugins/available-plugins",
     "plugins/CreatePlugin" => "plugins/create-plugin",
     "plugins/PluginsTroubleshooting" => "plugins/plugins-troubleshooting",
     "actions/Actions" => "actions",
-    "FAQs" => "faqs",
-    "best-practices/Gitignore" => "best-practices/source-control",
     "best-practices/gitignore" => "best-practices/source-control",
     "best-practices/SourceControl" => "best-practices/source-control",
-    "best-practices/ContinuousIntegration" => "best-practices/continuous-integration",
-    "best-practices/Keys" => "best-practices/keys",
-    "Advanced" => "advanced"
+    "best-practices/ContinuousIntegration" => "best-practices/continuous-integration"
   }
 end


### PR DESCRIPTION
Case-only redirects are causing infinite redirect loops in production, so this is a change to try to fix that.