### PR TITLE
Adding an alternate download option for Xcode command line tools

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -55,6 +55,9 @@ Make sure you have the latest version of the Xcode command line tools installed:
 xcode-select --install
 ```
 
+Alternatively, you can install the command line tools manually by visiting the following page:
+https://developer.apple.com/download/more/?name=command%20line%20tools
+
 ### Choose your installation method:
 
 <table width="100%">


### PR DESCRIPTION
xcode-select --install is yielding this nasty little error message (with no helpful information):

> can't install the software because it is not currently available from the software update server

I suggest we give users another option for how to download the command line tools.