### PR TITLE
Change eval to eval_gemfile for Pluginfile

### DIFF
--- a/docs/plugins/plugins-troubleshooting.md
+++ b/docs/plugins/plugins-troubleshooting.md
@@ -46,7 +46,7 @@ Your `Gemfile` should look something like this:
 gem "fastlane"
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
-eval(File.read(plugins_path), binding) if File.exist?(plugins_path)
+eval_gemfile(plugins_path) if File.exist?(plugins_path)
 ```
 
 Your `Pluginfile` should look something like this


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Apply https://github.com/fastlane/fastlane/pull/8282 changes to docs

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

Now `code_to_attach` in `plugin_manager.rb` has changed to use `eval_gemfile` instead of `eval`.
That's why it would be better that docs also use `eval_gemfile`.
