### PR TITLE
Add instructions for manual modification of fastlane match repo

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -389,11 +389,11 @@ you can expect the `app_identifier` to equal `"com.forplatform.mac.forlane.relea
 
 # Manually Manage the fastlane match Repo
 
-Most users can benefit from *match*'s automatic management of the repo that stores certificates and provisioning profiles. From time to time, it may be necessary to manually change the files in this repo.
+Most users can benefit from _match_'s automatic management of the repo that stores certificates and provisioning profiles. From time to time, it may be necessary to manually change the files in this repo.
 
 For example, fastlane requires admin access to the Apple Developer account to generate the appropriate files. If you are provided with an updated certificate or profile but do not have admin access, you can manually edit the repo.
 
-> **Warning:** Manually editing your *match* repo can introduce unexpected behavior and is not recommended. Proceed with caution.
+> **Warning:** Manually editing your _match_ repo can introduce unexpected behavior and is not recommended. Proceed with caution.
 
 <details>
 <summary>Instructions</summary>
@@ -413,14 +413,14 @@ it's necessary to manually decrypt, then modify, then encrypt, the repo to make 
 
 ### 🔓 Decryption Instructions
 
-The easiest way to decrypt the repo is to use the fastlane *match* `GitHelper` class. You can do this from an interactive Ruby console:
+The easiest way to decrypt the repo is to use the fastlane _match_ `GitHelper` class. You can do this from an interactive Ruby console:
 
 ```bash
 $ bundle console
 irb(main):001:0>
 ```
 
-Then, require *match* and set the appropriate parameters:
+Then, require _match_ and set the appropriate parameters:
 
 ```ruby
 irb(main):001:0> require 'match'
@@ -443,7 +443,7 @@ irb(main):005:0> workspace = Match::GitHelper.clone(git_url, shallow_clone, manu
 
 The directory beginning with `/var/folders` contains the decrypted git repo. Modify it as needed.
 
-If you are updating a `.p12` file, ensure it's exported from the keychain without a password, since *match* doesn't support importing private keys with a password.
+If you are updating a `.p12` file, ensure it's exported from the keychain without a password, since _match_ doesn't support importing private keys with a password.
 
 > **Warning:** Do *not* commit your changes. Allow the fastlane script to do that for you.
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -389,9 +389,16 @@ you can expect the `app_identifier` to equal `"com.forplatform.mac.forlane.relea
 
 # Manually Manage the fastlane match Repo
 
-Most users can benefit from fastlane match's automatic management of the repo that stores certificates and provisioning profiles. From time to time, it may be necessary to manually change the files in this repo.
+Most users can benefit from *match*'s automatic management of the repo that stores certificates and provisioning profiles. From time to time, it may be necessary to manually change the files in this repo.
 
 For example, fastlane requires admin access to the Apple Developer account to generate the appropriate files. If you are provided with an updated certificate or profile but do not have admin access, you can manually edit the repo.
+
+> **Warning:** Manually editing your *match* repo can introduce unexpected behavior and is not recommended. Proceed with caution.
+
+<details>
+<summary>Instructions</summary>
+
+
 
 ### Overview
 
@@ -406,14 +413,14 @@ it's necessary to manually decrypt, then modify, then encrypt, the repo to make 
 
 ### 🔓 Decryption Instructions
 
-The easiest way to decrypt the repo is to use the fastlane match `GitHelper` class. You can do this from an interactive Ruby console:
+The easiest way to decrypt the repo is to use the fastlane *match* `GitHelper` class. You can do this from an interactive Ruby console:
 
 ```bash
 $ bundle console
 irb(main):001:0>
 ```
 
-Then, require `match` and set the appropriate parameters:
+Then, require *match* and set the appropriate parameters:
 
 ```ruby
 irb(main):001:0> require 'match'
@@ -436,7 +443,7 @@ irb(main):005:0> workspace = Match::GitHelper.clone(git_url, shallow_clone, manu
 
 The directory beginning with `/var/folders` contains the decrypted git repo. Modify it as needed.
 
-If you are updating a `.p12` file, ensure it's exported from the keychain without a password, since match doesn't support importing private keys with a password.
+If you are updating a `.p12` file, ensure it's exported from the keychain without a password, since *match* doesn't support importing private keys with a password.
 
 > **Warning:** Do *not* commit your changes. Allow the fastlane script to do that for you.
 
@@ -453,3 +460,5 @@ irb(main):006:0> Match::GitHelper.commit_changes(workspace, "remove password fro
 Your changes will be encrypted, committed, and pushed.
 
 > **Note:** If your keychain doesn't include the encryption passcode, you may be prompted for it. If so, just enter the same password you used to decrypt it.
+
+</details>

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -391,7 +391,7 @@ you can expect the `app_identifier` to equal `"com.forplatform.mac.forlane.relea
 
 Most users can benefit from _match_'s automatic management of the repo that stores certificates and provisioning profiles. From time to time, it may be necessary to manually change the files in this repo.
 
-For example, fastlane requires admin access to the Apple Developer account to generate the appropriate files. If you are provided with an updated certificate or profile but do not have admin access, you can manually edit the repo.
+For example, _fastlane_ requires admin access to the Apple Developer account to generate the appropriate files. If you are provided with an updated certificate or profile but do not have admin access, you can manually edit the repo.
 
 > **Warning:** Manually editing your _match_ repo can introduce unexpected behavior and is not recommended. Proceed with caution.
 
@@ -404,16 +404,16 @@ For example, fastlane requires admin access to the Apple Developer account to ge
 
 Because:
 
-1. fastlane encrypts the repo, and
-2. fastlane doesn't support manual edits to the repo
+1. _fastlane_ encrypts the repo, and
+2. _fastlane_ doesn't support manual edits to the repo
 
 it's necessary to manually decrypt, then modify, then encrypt, the repo to make any changes.
 
-> These instructions presuppose you already have fastlane match configured correctly.
+> These instructions presuppose you already have _fastlane_ _match_ configured correctly.
 
 ### 🔓 Decryption Instructions
 
-The easiest way to decrypt the repo is to use the fastlane _match_ `GitHelper` class. You can do this from an interactive Ruby console:
+The easiest way to decrypt the repo is to use the _fastlane_ _match_ `GitHelper` class. You can do this from an interactive Ruby console:
 
 ```bash
 $ bundle console
@@ -445,7 +445,7 @@ The directory beginning with `/var/folders` contains the decrypted git repo. Mod
 
 If you are updating a `.p12` file, ensure it's exported from the keychain without a password, since _match_ doesn't support importing private keys with a password.
 
-> **Warning:** Do *not* commit your changes. Allow the fastlane script to do that for you.
+> **Warning:** Do *not* commit your changes. Allow _fastlane_ to do that for you.
 
 Once your changes are made, we'll need to encrypt the repo and push it.
 


### PR DESCRIPTION
As a stopgap while https://github.com/fastlane/fastlane/pull/6972 is in progress, let's provide some high-level instructions for users to update the match repo by hand.

I verified the change renders correctly locally:

![image](https://cloud.githubusercontent.com/assets/789577/23974449/863a17e8-0998-11e7-9a25-826aae282fbf.png)
