### PR TITLE
fix redirect from pointing to `/##hash` 

### DIFF
--- a/scripts/ci/generate_redirects.rb
+++ b/scripts/ci/generate_redirects.rb
@@ -9,7 +9,7 @@ docs_redirects.each do |from, to|
 
   full_path = File.join(from, "index.html")
   to = "/#{to}" unless to.start_with?("/")
-  content = "<script type='text/javascript'>window.location.href = '#{to}#' + window.location.hash;</script>"
+  content = "<script type='text/javascript'>window.location.href = '#{to}' + window.location.hash;</script>"
 
   File.write(full_path, content)
   puts "Successfully created file at path '#{full_path}' to point to '#{to}'"


### PR DESCRIPTION
https://docs.fastlane.tools/codesigning/GettingStarted#using-cert-and-sigh

redirects to with double hash:

https://docs.fastlane.tools/codesigning/getting-started/##using-cert-and-sigh

(and don't jump to section with `##`)
