### PR TITLE
Add another code sign gotcha to the Common Issues

### DIFF
--- a/docs/codesigning/common-issues.md
+++ b/docs/codesigning/common-issues.md
@@ -32,6 +32,10 @@ Your project defines a provisioning profile which doesn't exist on your local ma
 
 Make sure to have a valid code signing identity defined in your project targets. This might happen when you select `Don't Code Sign` as Code Signing Identity.
 
+> User interaction is not allowed. Command /usr/bin/codesign failed with exit code 1
+
+Make sure that codesign can access your signing private key. Open Keychain Access. Select your signing private key, right-click, choose Get Info, change to the Access Control tab and select the "Allow all applications to access this item".
+
 ## fastlane errors
 
 > Could not find a matching code signing identity for type 'X'


### PR DESCRIPTION
Make sure that the private key can be accessed by command line tools on the build machine.

This trips me up every time I have to re-create the production certificate plus all provisioning certificates and move them over to the build machine. 
