### PR TITLE
[WIP] Add Algolia docsearch bar on the breadcumb

### DIFF
--- a/docs/css/breadcrumbs.css
+++ b/docs/css/breadcrumbs.css
@@ -4,6 +4,11 @@
 
 .wy-breadcrumbs li.wy-breadcrumbs-aside {
   float: right;
+  padding-left: 20px;
+}
+
+.wy-breadcrumbs li.wy-breadcrumbs-aside input {
+  width: 250px;
 }
 
 .wy-breadcrumbs li a {
@@ -20,6 +25,18 @@
   color: #b3b3b3;
   font-size: 80%;
   display: inline-block;
+}
+
+.wy-breadcrumbs input[type=text] {
+  width: 100%;
+  color: #333;
+  border-radius: 3px;
+  outline: 0;
+  padding: 10px;
+  height: 30px;
+  background-color: #fff;
+  border: solid 1px #6d6d6d;
+  box-shadow: none
 }
 
 @media screen and (max-width: 480px) {

--- a/docs/css/sidenav.css
+++ b/docs/css/sidenav.css
@@ -200,17 +200,6 @@
   margin-bottom: .809em
 }
 
-.wy-side-nav-search input[type=text] {
-  width: 100%;
-  color: #333;
-  border-radius: 3px;
-  outline: 0;
-  padding: 10px;
-  background-color: #fff;
-  border: solid 1px #6d6d6d;
-  box-shadow: none
-}
-
 .wy-side-nav-search img {
   display: block;
   margin: auto auto .809em;

--- a/theme/breadcrumbs.html
+++ b/theme/breadcrumbs.html
@@ -30,6 +30,20 @@
         {% endif %}
       </li>
     {% endif %}
+    <li class="wy-breadcrumbs-aside">
+      <input type="text" name="q" placeholder="Search docs" />
+    </li>
   </ul>
   <hr/>
 </div>
+
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css" />
+<!-- at the end of the BODY -->
+<script type="text/javascript" src="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js"></script>
+<script type="text/javascript"> docsearch({
+    apiKey: 'c651753b86f5f8a00f8f2e9e9ca95865',
+    indexName: 'fastlane',
+    inputSelector: 'body > div.wy-grid-for-nav > section > div > div > div:nth-child(1) > ul > li.wy-breadcrumbs-aside > input[type="text"]',
+    debug: false
+});
+</script>


### PR DESCRIPTION
This is a WIP (addresses #413) to show you how Algolia DocSearch would look. You can try it out and see for yourself 🙂 .

Things to point out:
- We tried to customise the search area by creating a `main.html` and then add something like:
```
{% extends "base.html" %}

{% block search_box %}
// put <input>
{% endblock %}
```
Unfortunately we couldn't really make this work. But we were actually able to override the search area by creating a file `theme/searchbox.html`. 

Same problem for adding the extra headers with `extrahead`, so for now, we just dropped them to `breadcrumbs.html` just to show you a demo of how it would work.

- Speaking about having the search on the left, the autocomplete search result window is bigger than the width of the navbar, and so the results are being cut off. Even by playing with the `z-index` and `overflow` css classes, we couldn't make the results appear past the navbar.

- If you want to style the autocomplete experience, checkout the [configuration options](https://github.com/algolia/docsearch#customization). This includes both styling as well as customising search results.