### PR TITLE
[Docs] Make "Directory behavior" a primary heading

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -521,7 +521,7 @@ Your changes will be encrypted, committed, and pushed.
 
 </details>
 
-## Directory behavior
+# Directory behavior
 
 _fastlane_ was designed in a way that you can run _fastlane_ from both the root directory of the project, and from the `./fastlane` sub-folder.
 


### PR DESCRIPTION
This was a secondary heading before, but doesn't belong below "Manually Manage the fastlane match Repo".
