### PR TITLE
Mention locale environment variables in the docs

### DIFF
--- a/docs/best-practices/continuous-integration.md
+++ b/docs/best-practices/continuous-integration.md
@@ -25,6 +25,7 @@ Most setups will need the following environment variables
 - `FASTLANE_USER`: Your iTunes Connect / Dev Portal user, if your _fastlane_ setup accesses iTC or the DevPortal (e.g. submit a TestFlight build, create a profile, ...)
 - `MATCH_PASSWORD`: You need to provide the password of your _match_ encryption if you use _match_
 - `FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD`: You need to provide an [application specific password](#two-step-or-two-factor-auth) if you have 2-factor enabled and use _pilot_ or _deliver_ to upload a binary to iTunes Connect
+- `LANG` and `LC_ALL`: These set up the locale your shell and all the commands you execute run at. _fastlane_ needs these to be set to an UTF-8 locale to work correctly, for example `en_US.UTF-8`. Many CI systems come with a locale that is unset or set to ASCII by default, so make sure to double-check whether yours is set correctly.
 
 ## Deploy Strategy
 

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -114,3 +114,6 @@ Follow the on screen prompt to add a line to your _bash_/_zsh_ profile.
 
 This error can occur when you run _fastlane_ via SSH. To fix it check out [this reply on StackOverflow](https://stackoverflow.com/a/22637896/445598).
 
+### Some fastlane commands like _deliver_, _scan_, _gym_, or _pilot_ hang indefinitely or produce strange errors and symbols 
+
+Make sure your `LC_ALL` and `LANG` variables are set up correctly. _fastlane_ requires an UTF-8 environment, so setting those variables to `en_US.UTF-8` should fix your issues. Refer to the _fastlane_ [setup instructions](/getting-started/ios/setup/#set-up-environment-variables) for details.

--- a/docs/getting-started/android/setup.md
+++ b/docs/getting-started/android/setup.md
@@ -24,7 +24,7 @@
 
 ### Set up environment variables
 
-fastlane requires some environment variables set up to run correctly. In particular, having your locale not set to a UTF-8 locale will cause issues with building and uploading your build. In your shell profile add the following lines:
+_fastlane_ requires some environment variables set up to run correctly. In particular, having your locale not set to a UTF-8 locale will cause issues with building and uploading your build. In your shell profile add the following lines:
 
 ```sh
 export LC_ALL=en_US.UTF-8

--- a/docs/getting-started/android/setup.md
+++ b/docs/getting-started/android/setup.md
@@ -22,6 +22,17 @@
 </tr>
 </table>
 
+### Set up environment variables
+
+fastlane requires some environment variables set up to run correctly. In particular, having your locale not set to a UTF-8 locale will cause issues with building and uploading your build. In your shell profile add the following lines:
+
+```sh
+export LC_ALL=en_US.UTF-8
+export LANG=en_US.UTF-8
+```
+
+You can find your shell profile at `~/.bashrc`, `~/.bash_profile` or `~/.zshrc` depending on your system. 
+
 ## Setting up _fastlane_
 
 Navigate your terminal to your project's directory and run

--- a/docs/getting-started/ios/setup.md
+++ b/docs/getting-started/ios/setup.md
@@ -29,7 +29,7 @@ xcode-select --install
 
 ### Set up environment variables
 
-fastlane requires some environment variables set up to run correctly. In particular, having your locale not set to a UTF-8 locale will cause issues with building and uploading your build. In your shell profile add the following lines:
+_fastlane_ requires some environment variables set up to run correctly. In particular, having your locale not set to a UTF-8 locale will cause issues with building and uploading your build. In your shell profile add the following lines:
 
 ```sh
 export LC_ALL=en_US.UTF-8

--- a/docs/getting-started/ios/setup.md
+++ b/docs/getting-started/ios/setup.md
@@ -27,6 +27,17 @@ xcode-select --install
 </tr>
 </table>
 
+### Set up environment variables
+
+fastlane requires some environment variables set up to run correctly. In particular, having your locale not set to a UTF-8 locale will cause issues with building and uploading your build. In your shell profile add the following lines:
+
+```sh
+export LC_ALL=en_US.UTF-8
+export LANG=en_US.UTF-8
+```
+
+You can find your shell profile at `~/.bashrc`, `~/.bash_profile` or `~/.zshrc` depending on your system. 
+
 ## Setting up _fastlane_
 
 Navigate your terminal to your project's directory and run


### PR DESCRIPTION
See fastlane/fastlane#10988 

This makes locale environment variables that need to be set more explicit by mentioning them during setup, in the FAQs and in the CI setup guide