### PR TITLE
Update tab auto complete FAQ

### DIFF
--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -102,13 +102,15 @@ Set the `FASTLANE_DISABLE_COLORS` environment variable to disable ANSI colors (e
 export FASTLANE_DISABLE_COLORS=1
 ```
 
-### Enable _bash_/_zsh_/_fish_ tab auto complete for fastlane lane names
+### Enable tab auto complete for fastlane lane names
+
+Supported shells: _bash_, _zsh_, _fish_.
 
 ```no-highlight
 fastlane enable_auto_complete
 ```
 
-Follow the on screen prompt to add a line to your _bash_/_zsh_ profile.
+Follow the on screen prompt to add a line to your _bash_/_zsh_/_fish_ profile.
 
 ### "User interaction is not allowed" when using _fastlane_ via SSH
 

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -102,7 +102,7 @@ Set the `FASTLANE_DISABLE_COLORS` environment variable to disable ANSI colors (e
 export FASTLANE_DISABLE_COLORS=1
 ```
 
-### Enable _bash_/_zsh_ tab completion for fastlane lane names
+### Enable _bash_/_zsh_/_fish_ tab auto complete for fastlane lane names
 
 ```no-highlight
 fastlane enable_auto_complete


### PR DESCRIPTION
This adds fish to the list of supported shells for tab auto complete.
This enables searching for "auto complete" to find this FAQ.

The problem with this is that previous link (https://docs.fastlane.tools/faqs/#enable-bashzsh-tab-completion-for-fastlane-lane-names) wouldn't work anymore.

Is this something we can live with?

<!--
Thanks for contributing to _fastlane_! Before you submit your pull request, note that files in the docs folder covering Actions (actions.md and actions/*) and Plugins (available-plugins.md) are auto-generated.
If this is the case, please modify the documentation at their sources (https://github.com/fastlane/fastlane or plugin repository) and will be updated here regularly.
-->
