### PR TITLE
Update CircleCI integration section

### DIFF
--- a/docs/best-practices/continuous-integration.md
+++ b/docs/best-practices/continuous-integration.md
@@ -159,12 +159,12 @@ platform :ios do
 end
 ```
 
-The `setup_circle_ci` Fastlane action will perform the following actions:
+The `setup_circle_ci` _fastlane_ action will perform the following actions:
 
-* Create a new temporary keychain for use with Fastlane Match (see the
-  [CircleCI code signing doc](https://circleci.com/docs/2.0/ios-codesigning/)
-  for more details).
-* Switch Fastlane Match to readonly mode to make sure CI does not create new
+* Create a new temporary keychain for use with
+  [match](https://fastlane.tools/match) (see the [CircleCI code signing
+  doc](https://circleci.com/docs/2.0/ios-codesigning/) for more details).
+* Switch _match_ to readonly mode to make sure CI does not create new
   code signing certificates or provisioning profiles.
 * Set up log and test result paths to be easily collectible.
 
@@ -194,7 +194,7 @@ jobs:
           paths:
             - vendor/bundle
       - run:
-          name: Fastlane
+          name: fastlane
           command: bundle exec fastlane $FASTLANE_LANE
       - run:
           command: cp $FL_OUTPUT_DIR/scan/report.junit $FL_OUTPUT_DIR/scan/results.xml

--- a/docs/best-practices/continuous-integration.md
+++ b/docs/best-practices/continuous-integration.md
@@ -246,8 +246,8 @@ This will do the following:
 * Run the test lane on all pushes.
 * Create the ad-hoc build on each push (or merge) to the `development` branch.
 
-Check out [the CircleCI iOS doc](https://circleci.com/docs/2.0/testing-ios) for
-more detailed instructions and examples.
+Check out [the CircleCI iOS doc](https://circleci.com/docs/2.0/testing-ios/#example-configuration-for-using-fastlane-on-circleci)
+for more detailed instructions and examples.
 
 # Travis Integration
 

--- a/docs/best-practices/continuous-integration.md
+++ b/docs/best-practices/continuous-integration.md
@@ -179,9 +179,9 @@ jobs:
   build:
     macos:
       xcode: "9.0"
-    working_directory: /Users/distiller/output
+    working_directory: /Users/distiller/project
     environment:
-      FL_OUTPUT_DIR: $CIRCLE_WORKING_DIRECTORY
+      FL_OUTPUT_DIR: $CIRCLE_WORKING_DIRECTORY/output
       FASTLANE_LANE: test
     shell: /bin/bash --login -o pipefail
     steps:
@@ -200,7 +200,7 @@ jobs:
           command: cp $FL_OUTPUT_DIR/scan/report.junit $FL_OUTPUT_DIR/scan/results.xml
           when: always
       - store_artifacts:
-          path: /Users/distiller/output
+          path: /Users/distiller/project/output
       - store_test_results:
           path: /Users/distiller/output/scan
 ```

--- a/docs/best-practices/continuous-integration.md
+++ b/docs/best-practices/continuous-integration.md
@@ -203,51 +203,16 @@ jobs:
           path: /Users/distiller/output
       - store_test_results:
           path: /Users/distiller/output/scan
-
-  adhoc:
-    macos:
-      xcode: "9.0"
-    working_directory: /Users/distiller/output
-    environment:
-      FL_OUTPUT_DIR: $CIRCLE_WORKING_DIRECTORY
-      FASTLANE_LANE: adhoc
-    shell: /bin/bash --login -o pipefail
-    steps:
-      - checkout
-      - restore_cache:
-          key: 1-gems-{{ checksum "Gemfile.lock" }}
-      - run: bundle check || bundle install --path vendor/bundle
-      - save_cache:
-          key: 1-gems-{{ checksum "Gemfile.lock" }}
-          paths:
-            - vendor/bundle
-      - run:
-          name: Fastlane
-          command: bundle exec fastlane $FASTLANE_LANE
-      - store_artifacts:
-          path: /Users/distiller/output
-
-workflows:
-  version: 2
-  build-plus-adhoc:
-    jobs:
-      - build
-      - adhoc:
-          filters:
-            branches:
-              only: development
-          requires:
-            - build
-
 ```
 
 This will do the following:
 * Create and use a Ruby gems cache.
 * Run the test lane on all pushes.
-* Create the ad-hoc build on each push (or merge) to the `development` branch.
+* Collect Junit test results and store log output in the Artifacts tab.
 
-Check out [the CircleCI iOS doc](https://circleci.com/docs/2.0/testing-ios/#example-configuration-for-using-fastlane-on-circleci)
-for more detailed instructions and examples.
+Check out [the CircleCI iOS
+doc](https://circleci.com/docs/2.0/testing-ios/#example-configuration-for-using-fastlane-on-circleci)
+for more detailed examples of using fastlane on CircleCI.
 
 # Travis Integration
 

--- a/docs/best-practices/continuous-integration.md
+++ b/docs/best-practices/continuous-integration.md
@@ -181,7 +181,7 @@ jobs:
       xcode: "9.0"
     working_directory: /Users/distiller/project
     environment:
-      FL_OUTPUT_DIR: $CIRCLE_WORKING_DIRECTORY/output
+      FL_OUTPUT_DIR: /Users/distiller/project/output
       FASTLANE_LANE: test
     shell: /bin/bash --login -o pipefail
     steps:

--- a/docs/best-practices/continuous-integration.md
+++ b/docs/best-practices/continuous-integration.md
@@ -202,7 +202,7 @@ jobs:
       - store_artifacts:
           path: /Users/distiller/project/output
       - store_test_results:
-          path: /Users/distiller/output/scan
+          path: /Users/distiller/project/output/scan
 ```
 
 This will do the following:


### PR DESCRIPTION
Update the CircleCI integration section in the CI doc to use [CircleCI 2.0 for macOS](https://circleci.com/blog/one-more-thing-apple-developers-can-now-build-for-macos-ios-tvos-and-watchos-on-circleci-2-0/).

cc @DanToml 