### PR TITLE
Change Fastfile samples to use new core action names.

### DIFF
--- a/docs/codesigning/getting-started.md
+++ b/docs/codesigning/getting-started.md
@@ -32,9 +32,9 @@ Add the following lines to your `Fastfile`
 
 ```ruby
 lane :beta do
-  cert
-  sigh
-  gym
+  get_certificates           # invokes cert
+  get_provisioning_profile   # invokes sigh
+  build_app
 end
 ```
 
@@ -62,11 +62,11 @@ in your Fastfile you then use a lane like this:
 
 ```ruby
 lane :release do
-  match
+  sync_code_signing
   disable_automatic_code_signing(path: "my_project.xcodeproj")
-  gym
+  build_app
   enable_automatic_code_signing(path: "my_project.xcodeproj")
-  pilot
+  upload_to_testflight
 end
 ```
 

--- a/docs/codesigning/xcode-project.md
+++ b/docs/codesigning/xcode-project.md
@@ -8,7 +8,7 @@ If you don't use _match_, we recommend defining a mapping of app target to provi
 
 ```ruby
 lane :beta do
-  gym(
+  build_app(
     export_method: "app-store",
     export_options: {
       provisioningProfiles: { 

--- a/docs/getting-started/android/beta-deployment.md
+++ b/docs/getting-started/android/beta-deployment.md
@@ -39,7 +39,7 @@ After building your app, it's ready to be uploaded to a beta testing service of 
 ```ruby
 lane :beta do
   gradle(task: 'assemble', build_type: 'Release')
-  supply(track: 'beta')
+  upload_to_play_store(track: 'beta')
   slack(message: 'Successfully distributed a new beta build')
 end
 ```
@@ -49,7 +49,7 @@ end
 <details>
 <summary>Google Play</summary>
 
-In order to distribute to Google Play with _supply_ you will need to have your Google credentials set up. Make sure you've gone through [Setting up _supply_](setup/#setting-up-supply) before continuing!
+In order to distribute to Google Play with _upload_to_play_store_ you will need to have your Google credentials set up. Make sure you've gone through [Setting up _supply_](setup/#setting-up-supply) before continuing!
 
 ```ruby
 lane :beta do
@@ -58,7 +58,7 @@ lane :beta do
     task: 'assemble',
     build_type: 'Release'
   )
-  supply(track: 'beta')
+  upload_to_play_store(track: 'beta')
   # ...
 end
 ```
@@ -66,7 +66,7 @@ end
 To get a list of all available options, run:
 
 ```no-highlight
-fastlane action supply
+fastlane action upload_to_play_store
 ```
 
 ---

--- a/docs/getting-started/android/release-deployment.md
+++ b/docs/getting-started/android/release-deployment.md
@@ -37,7 +37,7 @@ lane :playstore do
     task: 'assemble',
     build_type: 'Release'
   )
-  supply # Uploads the APK built in the gradle step above
+  upload_to_play_store # Uploads the APK built in the gradle step above
 end
 ```
 
@@ -56,15 +56,15 @@ To gradually roll out a new build you can use:
 ```ruby
 lane :playstore do
   # ...
-  supply(
+  upload_to_play_store(
   	track: 'rollout',
   	rollout: '0.5'
   )
 end
 ```
 
-To get a list of all available parameters for the _supply_ action, run:
+To get a list of all available parameters for the _upload_to_play_store_ action, run:
 
 ```no-highlight
-fastlane action supply
+fastlane action upload_to_play_store
 ```

--- a/docs/getting-started/android/screenshots.md
+++ b/docs/getting-started/android/screenshots.md
@@ -150,16 +150,16 @@ Add the following code to your `fastlane/Fastfile`:
 
 ```ruby
 lane :screenshots do
-  screengrab
-  supply
+  capture_android_screenshots
+  upload_to_play_store
 end
 ```
 
 To get a list of all available options for each of the steps, run
 
 ```no-highlight
-fastlane action screengrab
-fastlane action supply
+fastlane action capture_android_screenshots
+fastlane action upload_to_play_store
 ```
 
 # Advanced _screengrab_

--- a/docs/getting-started/ios/appstore-deployment.md
+++ b/docs/getting-started/ios/appstore-deployment.md
@@ -2,11 +2,11 @@
 
 # Building your app
 
-_fastlane_ takes care of building your app using a feature called _gym_, just add the following to your `Fastfile`:
+_fastlane_ takes care of building your app using an action called _build_app_, just add the following to your `Fastfile`:
 
 ```
 lane :appstore do
-  gym(scheme: "MyApp")
+  build_app(scheme: "MyApp")
 end
 ```
 
@@ -14,9 +14,9 @@ Additionally you can specify more options for building your app, for example
 
 ```ruby
 lane :appstore do
-  gym(scheme: "MyApp",
-      workspace: "Example.xcworkspace",
-      include_bitcode: true)
+  build_app(scheme: "MyApp",
+            workspace: "Example.xcworkspace",
+            include_bitcode: true)
 end
 ```
 
@@ -26,7 +26,7 @@ Try running the lane using
 fastlane appstore
 ```
 
-If everything works, you should have a `[ProductName].ipa` file in the current directory. To get a list of all available parameters for _gym_, run `fastlane action gym`.
+If everything works, you should have a `[ProductName].ipa` file in the current directory. To get a list of all available parameters for _build_app_, run `fastlane action build_app`.
 
 ## Codesigning
 
@@ -44,15 +44,15 @@ After building your app, it's ready to be uploaded to the App Store. If you've a
 
 ```ruby
 lane :appstore do
-  snapshot                      # generate new screenshots for the App Store
-  match(type: "appstore")       # see code signing guide for more information
-  gym(scheme: "MyApp")          # build your app
-  appstore                      # upload your app to iTunes Connect
+  capture_screenshots                  # generate new screenshots for the App Store
+  sync_code_signing(type: "appstore")  # see code signing guide for more information
+  build_app(scheme: "MyApp")
+  upload_to_app_store                  # upload your app to iTunes Connect
   slack(message: "Successfully uploaded a new App Store build")
 end
 ```
 
-_fastlane_ automatically passes on information about the generated screenshots and the binary to the `appstore` action of your `Fastfile`.
+_fastlane_ automatically passes on information about the generated screenshots and the binary to the `upload_to_app_store` action of your `Fastfile`.
 
 For a list of all options for each of the steps run `fastlane action [action_name]`.
 
@@ -65,14 +65,14 @@ To make sure your latest push notification certificate is still valid during you
 
 ```ruby
 lane :appstore do
-  pem
+  get_push_certificate
   # ...
 end
 ```
 
-_pem_ will ensure your certificate is valid for at least another 2 weeks, and create a new one if it isn't.
+_get_push_certificate_ will ensure your certificate is valid for at least another 2 weeks, and create a new one if it isn't.
 
-If you don't have any push certificates already, _pem_ will create one for you and store locally in your project's directory. To get more information about the available options run `fastlane action pem`.
+If you don't have any push certificates already, _get_push_certificate_ will create one for you and store locally in your project's directory. To get more information about the available options run `fastlane action get_push_certificate`.
 
 </details>
 

--- a/docs/getting-started/ios/beta-deployment.md
+++ b/docs/getting-started/ios/beta-deployment.md
@@ -2,11 +2,11 @@
 
 # Building your app
 
-_fastlane_ takes care of building your app using a feature called _gym_, just add the following to your `Fastfile`:
+_fastlane_ takes care of building your app using an action called _build_app_, just add the following to your `Fastfile`:
 
 ```ruby
 lane :beta do
-  gym(scheme: "MyApp")
+  build_app(scheme: "MyApp")
 end
 ```
 
@@ -14,9 +14,9 @@ Additionally you can specify more options for building your app, for example
 
 ```ruby
 lane :beta do
-  gym(scheme: "MyApp",
-      workspace: "Example.xcworkspace",
-      include_bitcode: true)
+  build_app(scheme: "MyApp",
+            workspace: "Example.xcworkspace",
+            include_bitcode: true)
 end
 ```
 
@@ -26,7 +26,7 @@ Try running the lane using
 fastlane beta
 ```
 
-If everything works, you should have a `[ProductName].ipa` file in the current directory. To get a list of all available parameters for _gym_, run `fastlane action gym`.
+If everything works, you should have a `[ProductName].ipa` file in the current directory. To get a list of all available parameters for _build_app_, run `fastlane action build_app`.
 
 ## Codesigning
 
@@ -36,18 +36,18 @@ Chances are that something went wrong because of code signing at the previous st
 
 After building your app, it's ready to be uploaded to a beta testing service of your choice. The beauty of _fastlane_ is that you can easily switch beta provider, or even upload to multiple at once, without any extra work.
 
-All you have to do is to put the name of the beta testing provider of your choice after building the app using _gym_:
+All you have to do is to put the name of the beta testing provider of your choice after building the app using _build_app_:
 
 ```ruby
 lane :beta do
-  match(type: "appstore")       # see code signing guide for more information
-  gym(scheme: "MyApp")          # build your app
-  testflight                    # upload your app to TestFlight
+  sync_code_signing(type: "appstore")    # see code signing guide for more information
+  build_app(scheme: "MyApp")
+  upload_to_testflight
   slack(message: "Successfully distributed a new beta build")
 end
 ```
 
-_fastlane_ automatically passes on information about the generated `.ipa` file from _gym_ to the beta testing provider of your choice.
+_fastlane_ automatically passes on information about the generated `.ipa` file from _build_app_ to the beta testing provider of your choice.
 
 To get a list of all available parameters for a given action, run
 ```no-highlight
@@ -65,8 +65,8 @@ You can easily upload new builds to TestFlight (which is part of iTunes Connect)
 ```ruby
 lane :beta do
   # ...
-  gym
-  testflight
+  build_app
+  upload_to_testflight
 end
 ```
 
@@ -75,24 +75,24 @@ Some example use cases
 ```ruby
 lane :beta do
   # ...
-  gym
+  build_app
 
   # Variant 1: Provide a changelog to your build
-  testflight(changelog: "Add rocket emoji")
+  upload_to_testflight(changelog: "Add rocket emoji")
 
   # Variant 2: Skip the "Waiting for processing" of the binary
   #   While this will speed up your build, it will not distribute
   #   the binary to your tests, nor set a changelog
-  testflight(skip_waiting_for_build_processing: true)
+  upload_to_testflight(skip_waiting_for_build_processing: true)
 end
 ```
 
-If you used `fastlane init` to setup _fastlane_, your Apple ID is stored in the `fastlane/Appfile`. You can also overwrite the username, using `testflight(username: "bot@fastlane.tools")`.
+If you used `fastlane init` to setup _fastlane_, your Apple ID is stored in the `fastlane/Appfile`. You can also overwrite the username, using `upload_to_testflight(username: "bot@fastlane.tools")`.
 
 To get a list of all available options, run
 
 ```no-highlight
-fastlane action testflight
+fastlane action upload_to_testflight
 ```
 
 With _fastlane_, you can also automatically manage your beta testers, check out TODO for more information.
@@ -106,7 +106,7 @@ With _fastlane_, you can also automatically manage your beta testers, check out 
 ```ruby
 lane :beta do
   # ...
-  gym
+  build_app
   crashlytics(api_token: "[insert_key_here]",
               build_secret: "[insert_key_here]")
 end
@@ -132,7 +132,7 @@ TODO: Also mention the other onboarding method
 ```ruby
 lane :beta do
   # ...
-  gym
+  build_app
   hockey(api_token: "[insert_key_here]")
 end
 ```
@@ -153,7 +153,7 @@ fastlane action hockey
 ```ruby
 lane :beta do
   # ...
-  gym
+  build_app
 
   testfairy(api_key: "[insert_key_here]")
 
@@ -186,11 +186,11 @@ Your changelog changes, so it doesn't make a lot of sense to store a static rele
 
 ```ruby
 lane :beta do
-  match
-  gym
+  sync_code_signing
+  build_app
 
   changelog_from_git_commits # this will generate the changelog based on your last commits
-  testflight
+  upload_to_testflight
 end
 ```
 
@@ -222,10 +222,10 @@ lane :beta do
     multi_line_end_keyword: "END"
   )
 
-  match
-  gym
+  sync_code_signing
+  build_app
 
-  testflight(changelog: changelog)
+  upload_to_testflight(changelog: changelog)
 end
 ```
 
@@ -246,10 +246,10 @@ lane :beta do
   # Variant 2: Fetch data from a remote web server
   changelog = download(url: "https://lookatmycms.com/changelog.txt")
 
-  match
-  gym
+  sync_code_signing
+  build_app
 
-  testflight(changelog: changelog)
+  upload_to_testflight(changelog: changelog)
 end
 ```
 
@@ -303,8 +303,8 @@ lane :beta do
 
   # After registering the new devices, we'll make sure to update the provisioning profile if necessary
   # Note how we make sure to pass "adhoc" to get and use a provisioning profile for Ad Hoc distribution
-  match(force_for_new_devices: true, type: "adhoc")
-  gym
+  sync_code_signing(force_for_new_devices: true, type: "adhoc")
+  build_app
   # ...
 end
 ```

--- a/docs/getting-started/ios/screenshots.md
+++ b/docs/getting-started/ios/screenshots.md
@@ -161,16 +161,16 @@ Add the following code to your `fastlane/Fastfile`:
 
 ```ruby
 lane :screenshots do
-  snapshot
-  deliver
+  capture_screenshots
+  upload_to_app_store
 end
 ```
 
 To get a list of all available options for each of the steps, run
 
 ```no-highlight
-fastlane action snapshot
-fastlane action deliver
+fastlane action capture_screenshots
+fastlane action upload_to_app_store
 ```
 
 # Put Your Screenshots Into Device Frames
@@ -245,16 +245,16 @@ To add the framing to your deployment process, use the following code in your `F
 
 ```ruby
 lane :screenshots do
-  snapshot
-  frameit(white: true)
-  deliver
+  capture_screenshots
+  frame_screenshots(white: true)
+  upload_to_app_store
 end
 ```
 
-To get a list of all available options for _frameit_
+To get a list of all available options for _frame_screenshots_ (which calls into _frameit_)
 
 ```no-highlight
-fastlane action frameit
+fastlane action frame_screenshots
 ```
 
 # Advanced _snapshot_
@@ -264,7 +264,7 @@ fastlane action frameit
 
 ```ruby
 lane :screenshots do
-  snapshot
+  capture_screenshots
 end
 ```
 
@@ -273,43 +273,43 @@ Your screenshots will be stored in the `./screenshots/` folder by default (or `.
 If any error occurs while running the snapshot script on a device, that device will not have any screenshots, and _snapshot_ will continue with the next device or language. To stop the flow after the first error, run
 
 ```ruby
-snapshot(stop_after_first_error: true)
+capture_screenshots(stop_after_first_error: true)
 ```
 
 Also by default, _snapshot_ will open the HTML after all is done. This can be skipped with the following command
 
 ```ruby
-snapshot(skip_open_summary: true)
+capture_screenshots(skip_open_summary: true)
 ```
 
 There are a lot of options available that define how to build your app, for example
 
 ```ruby
-snapshot(scheme: "UITests", configuration: "Release", sdk: "iphonesimulator")
+capture_screenshots(scheme: "UITests", configuration: "Release", sdk: "iphonesimulator")
 ```
 
 Reinstall the app before running _snapshot_
 
 ```ruby
-snapshot(reinstall_app: true, app_identifier: "tools.fastlane.app")
+capture_screenshots(reinstall_app: true, app_identifier: "tools.fastlane.app")
 ```
 
 By default _snapshot_ automatically retries running UI Tests if they fail. This is due to randomly failing UI Tests (e.g. [#372](https://github.com/fastlane/snapshot/issues/372)). You can adapt this number using
 
 ```ruby
-snapshot(number_of_retries: 3)
+capture_screenshots(number_of_retries: 3)
 ```
 
 Add photos and/or videos to the simulator before running _snapshot_
 
 ```ruby
-snapshot(add_photos: "MyTestApp/demo.jpg", add_videos: "MyTestApp/demo.mp4")
+capture_screenshots(add_photos: "MyTestApp/demo.jpg", add_videos: "MyTestApp/demo.mp4")
 ```
 
 For a list for all available options run
 
 ```no-highlight
-fastlane action snapshot
+fastlane action capture_screenshots
 ```
 </details>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,14 +14,14 @@ You can start by creating a `Fastfile` file in your repository, here’s one tha
 ```ruby
 lane :beta do
   increment_build_number
-  gym                       # Build your app
-  testflight                # Upload to TestFlight
+  build_app
+  upload_to_testflight
 end
 
 lane :appstore do
-  snapshot                  # Generate screenshots for the App Store
-  gym                       # Build your app
-  deliver                   # Upload the screenshots and the binary to iTunes
+  capture_screenshots
+  build_app
+  upload_to_app_store       # Upload the screenshots and the binary to iTunes
   slack                     # Let your team-mates know the new version is live
 end
 ```


### PR DESCRIPTION
<!--
Thanks for contributing to _fastlane_! Before you submit your pull request, note that files in the docs folder covering Actions (actions.md and actions/*) and Plugins (available-plugins.md) are auto-generated.
If this is the case, please modify the documentation at their sources (https://github.com/fastlane/fastlane or plugin repository) and will be updated here regularly.
-->
We have renamed the core actions (e.g., `pilot` -> `upload_to_testflight`) in [this PR](https://github.com/fastlane/fastlane/pull/10939). This changes the documentation to reference these new actions. These actions should make for easier-to-read `Fastfile`s.