### PR TITLE
Put the installer script method first

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -59,8 +59,8 @@ xcode-select --install
 
 <table width="100%">
 <tr>
-<th width="33%"><a href="http://brew.sh">Homebrew</a></td>
 <th width="33%">Installer Script</td>
+<th width="33%"><a href="http://brew.sh">Homebrew</a></td>
 <th width="33%">Rubygems</td>
 </tr>
 <tr>
@@ -69,8 +69,8 @@ xcode-select --install
 <td width="33%" align="center">macOS or Linux with Ruby 2.0.0 or above</td>
 </tr>
 <tr> 
-<td width="33%"><code>brew cask install fastlane</code></td>
 <td width="33%"><a href="https://download.fastlane.tools">Download the zip file</a>. Then double click on the <code>install</code> script (or run it in a terminal window).</td>
+<td width="33%"><code>brew cask install fastlane</code></td>
 <td width="33%"><code>sudo gem install fastlane -NV</code></td>
 </tr>
 </table>


### PR DESCRIPTION
Installing via Homebrew gives an inferior user experience, with constant prompting to use a Gemfile and an associated 2-second startup delay.

<!--
Thanks for contributing to _fastlane_! Before you submit your pull request, note that files in the docs folder covering Actions (actions.md and actions/*) and Plugins (available-plugins.md) are auto-generated.
If this is the case, please modify the documentation at their sources (https://github.com/fastlane/fastlane or plugin repository) and will be updated here regularly.
-->
