### PR TITLE
Add link to guides at bottom of landing page for people who scroll fast

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -124,3 +124,8 @@ You can easily opt-out of crash reporting by adding `opt_out_crash_reporting` at
 This project is licensed under the terms of the MIT license. See the [LICENSE](https://github.com/fastlane/fastlane/blob/master/LICENSE) file.
 
 > This project and all fastlane tools are in no way affiliated with Apple Inc. This project is open source under the MIT license, which means you have full access to the source code and can modify it to fit your own needs. All fastlane tools run on your own computer or server, so your credentials or other sensitive information will never leave your own computer. You are responsible for how you use fastlane tools.
+
+----
+### Where to go from here?
+- [fastlane Getting Started guide for iOS](getting-started/ios/setup.md)
+- [fastlane Getting Started guide for Android](getting-started/android/setup.md)


### PR DESCRIPTION
This is pretty useful as many people might miss the "Next Steps" section in the middle of the page