### PR TITLE
Refactor installation methods for fastlane

### DIFF
--- a/docs/getting-started/android/setup.md
+++ b/docs/getting-started/android/setup.md
@@ -2,24 +2,11 @@
 
 ## Installing _fastlane_
 
-### Choose your installation method:
-
-| Method                     | OS support                              | Description                                                                                                                           |
-|----------------------------|-----------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
-| [Homebrew](http://brew.sh) | macOS                                   | `brew cask install fastlane`                                                                                                          |
-| Installer Script           | macOS                                   | [Download the zip file](https://download.fastlane.tools). Then double click on the `install` script (or run it in a terminal window). |
-| RubyGems                   | macOS or Linux with Ruby 2.0.0 or above | `sudo gem install fastlane -NV`                                                                                                       |
-
-### Set up environment variables
-
-_fastlane_ requires some environment variables set up to run correctly. In particular, having your locale not set to a UTF-8 locale will cause issues with building and uploading your build. In your shell profile add the following lines:
-
-```sh
-export LC_ALL=en_US.UTF-8
-export LANG=en_US.UTF-8
+Install _fastlane_ using 
+```no-highlight
+[sudo] gem install fastlane -NV
 ```
-
-You can find your shell profile at `~/.bashrc`, `~/.bash_profile` or `~/.zshrc` depending on your system. 
+or alternatively using `brew cask install fastlane`
 
 ## Setting up _fastlane_
 
@@ -99,11 +86,21 @@ _fastlane_ is ready to generate screenshots and automatically distribute new bui
 - [_fastlane_ screenshots for Android](screenshots.md)
 - [Deploy to Google Play using _fastlane_](release-deployment.md)
 
+### Set up environment variables
+
+_fastlane_ requires some environment variables set up to run correctly. In particular, having your locale not set to a UTF-8 locale will cause issues with building and uploading your build. In your shell profile add the following lines:
+
+```sh
+export LC_ALL=en_US.UTF-8
+export LANG=en_US.UTF-8
+```
+
+You can find your shell profile at `~/.bashrc`, `~/.bash_profile` or `~/.zshrc` depending on your system. 
+
 ### Use a Gemfile
 
 It is recommended that you use a `Gemfile` to define your dependency on _fastlane_. This will clearly define the used _fastlane_ version, and its dependencies, and will also speed up using _fastlane_.
 
-- Install [bundler](https://bundler.io/) using `sudo gem install bundler`
 - Create a `./Gemfile` in the root directory of your project with the content
 ```ruby
 source "https://rubygems.org"
@@ -113,4 +110,4 @@ gem "fastlane"
 - Run `[sudo] bundle update` and add both the `./Gemfile` and the `./Gemfile.lock` to version control
 - Every time you run _fastlane_, use `bundle exec fastlane [lane]`
 - On your CI, add `[sudo] bundle install` as your first build step
-- To update _fastlane_, just run `[sudo] bundle update`
+- To update _fastlane_, just run `[sudo] bundle update fastlane`

--- a/docs/getting-started/ios/setup.md
+++ b/docs/getting-started/ios/setup.md
@@ -7,13 +7,17 @@ Make sure you have the latest version of the Xcode command line tools installed:
 xcode-select --install
 ```
 
-### Choose your installation method:
+Install _fastlane_ using 
+```no-highlight
+[sudo] gem install fastlane -NV
+```
+or alternatively using `brew cask install fastlane`
 
-| Method                     | OS support                              | Description                                                                                                                           |
-|----------------------------|-----------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
-| [Homebrew](http://brew.sh) | macOS                                   | `brew cask install fastlane`                                                                                                          |
-| Installer Script           | macOS                                   | [Download the zip file](https://download.fastlane.tools). Then double click on the `install` script (or run it in a terminal window). |
-| RubyGems                   | macOS or Linux with Ruby 2.0.0 or above | `sudo gem install fastlane -NV`                                                                                                       |
+Navigate to your iOS or Android app and run
+
+```no-highlight
+fastlane init
+```
 
 ## Setting up _fastlane_
 

--- a/docs/getting-started/ios/setup.md
+++ b/docs/getting-started/ios/setup.md
@@ -1,6 +1,7 @@
 # Getting started with _fastlane_ for iOS
 
 ## Installing _fastlane_
+
 Make sure you have the latest version of the Xcode command line tools installed:
 
 ```no-highlight
@@ -13,7 +14,7 @@ Install _fastlane_ using
 ```
 or alternatively using `brew cask install fastlane`
 
-Navigate to your iOS or Android app and run
+Navigate to your project directory and run
 
 ```no-highlight
 fastlane init
@@ -66,7 +67,6 @@ You can find your shell profile at `~/.bashrc`, `~/.bash_profile` or `~/.zshrc` 
 
 It is recommended that you use a `Gemfile` to define your dependency on _fastlane_. This will clearly define the used _fastlane_ version, and its dependencies, and will also speed up using _fastlane_.
 
-- Install [bundler](https://bundler.io/) using `sudo gem install bundler`
 - Create a `./Gemfile` in the root directory of your project with the content
 ```ruby
 source "https://rubygems.org"
@@ -76,4 +76,4 @@ gem "fastlane"
 - Run `[sudo] bundle update` and add both the `./Gemfile` and the `./Gemfile.lock` to version control
 - Every time you run _fastlane_, use `bundle exec fastlane [lane]`
 - On your CI, add `[sudo] bundle install` as your first build step
-- To update _fastlane_, just run `[sudo] bundle update`
+- To update _fastlane_, just run `[sudo] bundle update fastlane`

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,13 +55,13 @@ Make sure you have the latest version of the Xcode command line tools installed:
 xcode-select --install
 ```
 
-### Choose your installation method:
+### Install fastlane
 
-| Method                     | OS support                              | Description                                                                                                                           |
-|----------------------------|-----------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
-| [Homebrew](http://brew.sh) | macOS                                   | `brew cask install fastlane`                                                                                                          |
-| Installer Script           | macOS                                   | [Download the zip file](https://download.fastlane.tools). Then double click on the `install` script (or run it in a terminal window). |
-| RubyGems                   | macOS or Linux with Ruby 2.0.0 or above | `sudo gem install fastlane -NV`                                                                                                       |
+Install fastlane using 
+```no-highlight
+[sudo] gem install fastlane -NV
+```
+or alternatively using `brew cask install fastlane`
 
 Navigate to your iOS or Android app and run
 


### PR DESCRIPTION
This is not done yet, but even if we automatically generate a Gemfile for the user, we still need to install fastlane for them.
1) to install fastlane and run `fastlane init`
2) to install `bundler` for them
See implementation https://github.com/fastlane/fastlane/pull/11582

So once it's installed, we'd then automatically setup and use a Gemfile for the user, and even with a proposal to automatically do `bundle exec` for the user with https://github.com/fastlane/fastlane/pull/11588

<img width="1443" alt="screen shot 2018-01-16 at 3 24 03 pm" src="https://user-images.githubusercontent.com/869950/35010674-a5ae440c-fad1-11e7-9168-25944eb6fb9e.png">
<img width="1330" alt="screen shot 2018-01-16 at 3 23 51 pm" src="https://user-images.githubusercontent.com/869950/35010675-a82c3af4-fad1-11e7-8048-a753e5f5dd24.png">
<img width="1421" alt="screen shot 2018-01-16 at 3 23 36 pm" src="https://user-images.githubusercontent.com/869950/35010680-aa67ac36-fad1-11e7-8d8c-db2077c0d9e9.png">



Let me know what y'all think 👍 