### PR TITLE
Instruction Omissions

### DIFF
--- a/docs/getting-started/ios/screenshots.md
+++ b/docs/getting-started/ios/screenshots.md
@@ -92,7 +92,7 @@ XCUIApplication *app = [[XCUIApplication alloc] init];
 [Snapshot setupSnapshot:app];
 [app launch];
 ```
-1. In the terminal run `fastlane snapshot`.  WARNING: Running the test in Xcode will not create the snapshots is insufficient and will not generate the correct results - although no tests will fail.  The command line program creates the necessary subdirectories and renames the files as appropriate.
+1. In the terminal run `fastlane snapshot`.  WARNING: Running the test in Xcode does not create the snapshots, is insufficient, and will not generate the correct results - although no tests will fail.  The command line program creates the necessary subdirectories, renames the files as appropriate, and generates the overview html page.
 
 The setup process will also generate a `Snapfile`, looking similar to
 

--- a/docs/getting-started/ios/screenshots.md
+++ b/docs/getting-started/ios/screenshots.md
@@ -65,6 +65,8 @@ To jump-start your UI tests, you can use the UI Test recorder, which you can sta
 1. Run `fastlane snapshot init` in your project folder
 1. Add the `./SnapshotHelper.swift` file to your UI Test target (You can move the file anywhere you want)
 1. Add a new Xcode scheme for the newly created UI Test target
+1. Edit the scheme
+1. In the list on the left click "Build", and enable the checkbox under the "Run" column for your target. 
 1. Enable the `Shared` box of the newly created scheme
 1. (Objective C only) Add the bridging header to your test class.
     - `#import "MYUITests-Swift.h"`
@@ -90,7 +92,7 @@ XCUIApplication *app = [[XCUIApplication alloc] init];
 [Snapshot setupSnapshot:app];
 [app launch];
 ```
-
+1. In the terminal run `fastlane snapshot`.  WARNING: Running the test in Xcode will not create the snapshots is insufficient and will not generate the correct results - although no tests will fail.  The command line program creates the necessary subdirectories and renames the files as appropriate.
 
 The setup process will also generate a `Snapfile`, looking similar to
 

--- a/docs/getting-started/ios/screenshots.md
+++ b/docs/getting-started/ios/screenshots.md
@@ -77,23 +77,23 @@ To jump-start your UI tests, you can use the UI Test recorder, which you can sta
     - Objective C: `[Snapshot snapshot:@"01LoginScreen" waitForLoadingIndicator:YES];`
 1. Add the following code to your `setUp()` method:
 
-**Swift**
+    **Swift**
 
-```swift
-let app = XCUIApplication()
-setupSnapshot(app)
-app.launch()
-```
-
-**Objective C**
-
-```objective-c
-XCUIApplication *app = [[XCUIApplication alloc] init];
-[Snapshot setupSnapshot:app];
-[app launch];
-```
-12. In the terminal run `fastlane snapshot`.  
-WARNING: Running the test in Xcode does not create the snapshots, is insufficient, and will not generate the correct results - although no tests will fail.  The command line program creates the necessary subdirectories, renames the files as appropriate, and generates the overview html page.
+    ```swift
+    let app = XCUIApplication()
+    setupSnapshot(app)
+    app.launch()
+    ```
+    
+    **Objective C**
+    
+    ```objective-c
+    XCUIApplication *app = [[XCUIApplication alloc] init];
+    [Snapshot setupSnapshot:app];
+    [app launch];
+    ```
+1. In the terminal run `fastlane snapshot`.  
+WARNING: Running the test in Xcode does not create the snapshots and will not generate the correct results - although no tests will fail.  The command line program creates the necessary subdirectories, renames the files as appropriate, and generates the overview html page.
 
 The setup process will also generate a `Snapfile`, looking similar to
 

--- a/docs/getting-started/ios/screenshots.md
+++ b/docs/getting-started/ios/screenshots.md
@@ -92,7 +92,8 @@ XCUIApplication *app = [[XCUIApplication alloc] init];
 [Snapshot setupSnapshot:app];
 [app launch];
 ```
-1. In the terminal run `fastlane snapshot`.  WARNING: Running the test in Xcode does not create the snapshots, is insufficient, and will not generate the correct results - although no tests will fail.  The command line program creates the necessary subdirectories, renames the files as appropriate, and generates the overview html page.
+12. In the terminal run `fastlane snapshot`.  
+WARNING: Running the test in Xcode does not create the snapshots, is insufficient, and will not generate the correct results - although no tests will fail.  The command line program creates the necessary subdirectories, renames the files as appropriate, and generates the overview html page.
 
 The setup process will also generate a `Snapfile`, looking similar to
 


### PR DESCRIPTION
The instructions failed to mention that you need to set the Run checkbox on the scheme and that you need to execute this on the command line, not within the Xcode UI.

<!--
Thanks for contributing to _fastlane_! Before you submit your pull request, note that files in the docs folder covering Actions (actions.md and actions/*) and Plugins (available-plugins.md) are auto-generated.
If this is the case, please modify the documentation at their sources (https://github.com/fastlane/fastlane or plugin repository) and will be updated here regularly.
-->
