### PR TITLE
Updated Broken links

### DIFF
--- a/docs/codesigning/getting-started.md
+++ b/docs/codesigning/getting-started.md
@@ -17,7 +17,8 @@ If you are new to code signing, check out the [WWDC session](https://developer.a
 
 The concept of [match](https://fastlane.tools/match) is described in the [codesigning guide](https://codesigning.guide). 
 
-With [match](https://fastlane.tools/match) you store your private keys and certificates in a git repo to sync them across machines. This makes it easy to onboard new team-members and set up new Mac machines. This approach [is secure](https://github.com/fastlane/fastlane/tree/master/match#is-this-secure) and uses technology you already use.
+With [match](https://fastlane.tools/match) you store your private keys and certificates in a git repo to sync them across machines. This makes it easy to onboard new team-members and set up new Mac machines. This approach [is secure](https://docs.fastlane.tools/actions/match/#is-this-secure) and uses technology you already use.
+
 
 Getting started with [match](https://fastlane.tools/match) requires you to revoke your existing certificates.
 

--- a/docs/getting-started/ios/screenshots.md
+++ b/docs/getting-started/ios/screenshots.md
@@ -200,7 +200,7 @@ fastlane frameit
 
 This will only add a device frame around the screenshots, not the background and title. Those images can be used for your website, email newsletter and similar.
 
-If you want to implement the custom titles and background, you'll have to setup a `Framefile.json`, more information can be found [here](https://github.com/fastlane/fastlane/tree/master/frameit#titles-and-background-optional).
+If you want to implement the custom titles and background, you'll have to setup a `Framefile.json`, more information can be found [here](https://docs.fastlane.tools/actions/frameit/#titles-and-background-optional).
 
 If you want to upload the screenshots to the App Store, you **have** to provide a `Framefile.json`, with titles and background, otherwise the resolution of the framed screenshots doesn't match the requirements of iTunes Connect.
 


### PR DESCRIPTION
changed broken link
`github docs` -> `https://docs.fastlane.tools`