### PR TITLE
Update SSL FAQ to include Hockey CDN bypass

### DIFF
--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -20,6 +20,17 @@ If you use `rvm`, try the following
 rvm osx-ssl-certs update all
 ```
 
+If you are uploading to Hockey and still receive an SSL error (especially on a corporate firewall), try bypassing the CDN:
+
+```ruby
+hockey(
+  api_token: "...",
+  ipa: "./app.ipa",
+  notes: "Changelog",
+  bypass_cdn: true
+)
+```
+
 ### fastlane is slow (to start)
 
 If you experience slow launch times of _fastlane_, there are 2 solutions to solve this problem:


### PR DESCRIPTION
I have encountered SSL errors with Hockey a few times, resolved only by bypassing the CDN.  This doesn't appear anywhere in the SSL FAQs and could provide help to others.