### PR TITLE
Add Match manual for handling multiple apps per developer account

### DIFF
--- a/docs/actions/match.md
+++ b/docs/actions/match.md
@@ -163,7 +163,7 @@ Then all your team has to do is `fastlane certificates` and keys, certs and prof
 
 #### Handle multiple apps per developer/distribution certificate
 
-If you want to use single developer and distribution certificate for multiple apps belonging to the same development team, you may use the same signing identities repo and branch to store signing identities for your apps:
+If you want to use a single developer and distribution certificate for multiple apps belonging to the same development team, you may use the same signing identities repository and branch to store the signing identities for your apps:
 
 Matchfile for App #1:
 ```no-highlight
@@ -176,7 +176,7 @@ Matchfile for App #2:
 git_url "https://github.com/example/example-repo.git"
 git_branch "master"
 ```
-Match will reuse developer/distribution certificate and will create separate provisioning profiles for each app.
+_match_ will reuse certificates and will create separate provisioning profiles for each app.
 
 #### Passphrase
 

--- a/docs/actions/match.md
+++ b/docs/actions/match.md
@@ -163,7 +163,7 @@ Then all your team has to do is `fastlane certificates` and keys, certs and prof
 
 #### Handle multiple apps per developer/distribution certificate
 
-If you want to use a single developer and distribution certificate for multiple apps belonging to the same development team, you may use the same signing identities repository and branch to store the signing identities for your apps:
+If you want to use a single developer and/or distribution certificate for multiple apps belonging to the same development team, you may use the same signing identities repository and branch to store the signing identities for your apps:
 
 Matchfile for App #1:
 ```no-highlight

--- a/docs/actions/match.md
+++ b/docs/actions/match.md
@@ -161,6 +161,23 @@ end
 
 Then all your team has to do is `fastlane certificates` and keys, certs and profiles for all targets will be synced.
 
+#### Handle multiple apps per developer/distribution certificate
+
+If you want to use single developer and distribution certificate for multiple apps belonging to the same development team, you may use the same signing identities repo and branch to store signing identities for your apps:
+
+Matchfile for App #1:
+```no-highlight
+git_url "https://github.com/example/example-repo.git"
+git_branch "master"
+```
+
+Matchfile for App #2:
+```no-highlight
+git_url "https://github.com/example/example-repo.git"
+git_branch "master"
+```
+Match will reuse developer/distribution certificate and will create separate provisioning profiles for each app.
+
 #### Passphrase
 
 When running _match_ for the first time on a new machine, it will ask you for the passphrase for the Git repository. This is an additional layer of security: each of the files will be encrypted using `openssl`. Make sure to remember the password, as you'll need it when you run match on a different machine.


### PR DESCRIPTION
A clear guidance on how to use the same development and/or distribution certificate for multiple apps from the same development team.

<!--
Thanks for contributing to _fastlane_! Before you submit your pull request, note that files in the docs folder covering Actions (actions.md and actions/*) and Plugins (available-plugins.md) are auto-generated.
If this is the case, please modify the documentation at their sources (https://github.com/fastlane/fastlane or plugin repository) and will be updated here regularly.
-->
