### PR TITLE
Update location of the Service Account User role

### DIFF
--- a/docs/getting-started/android/setup.md
+++ b/docs/getting-started/android/setup.md
@@ -47,7 +47,7 @@ Setting it up requires downloading a credentials file from your Google Developer
 1. Click the **Create Service Account** button and follow the **Google Developers Console** link in the dialog
 1. Click the **Create Service account** button at the top of the developers console screen
 1. Provide a name for the service account
-1. Click **Select a role** and choose **Project > Service Account User**
+1. Click **Select a role** and choose **Service Accounts > Service Account User**
 1. Check the **Furnish a new private key** checkbox
 1. Select **JSON** as the Key type
 1. Click **Create** to close the dialog


### PR DESCRIPTION
It's now under 'Service Accounts'

![screenshot at mar 09 18-36-47](https://user-images.githubusercontent.com/3391093/37232149-7dbbdf44-23cc-11e8-8bb8-62b6d44a3df9.png)
