### PR TITLE
Fixed documentation issue for prompting changelog

### DIFF
--- a/docs/getting-started/ios/beta-deployment.md
+++ b/docs/getting-started/ios/beta-deployment.md
@@ -213,7 +213,7 @@ You can automatically be asked for the changelog in your terminal using the `pro
 ```ruby
 lane :beta do
   # Variant 1: Ask for a one line input
-  changelog = prompt("Changelog: ")
+  changelog = prompt(text: "Changelog: ")
 
   # Variant 2: Ask for a multi-line input
   #   The user confirms their input by typing `END` and Enter


### PR DESCRIPTION
Will otherwise result in an error
```
[!] You have to call the integration like `prompt(key: "value")`. Run `fastlane action prompt` for all available keys. Please check out the current documentation on GitHub.
```
