### PR TITLE
Update Fastlane docs to reflect current best practices for CircleCI

### DIFF
--- a/docs/best-practices/continuous-integration.md
+++ b/docs/best-practices/continuous-integration.md
@@ -206,7 +206,7 @@ jobs:
       xcode: "9.0"
     working_directory: /Users/distiller/project
     environment:
-      FL_OUTPUT_DIR: /Users/distiller/project/output
+      FL_OUTPUT_DIR: output
       FASTLANE_LANE: test
     shell: /bin/bash --login -o pipefail
     steps:
@@ -221,13 +221,10 @@ jobs:
       - run:
           name: fastlane
           command: bundle exec fastlane $FASTLANE_LANE
-      - run:
-          command: cp $FL_OUTPUT_DIR/scan/report.junit $FL_OUTPUT_DIR/scan/results.xml
-          when: always
       - store_artifacts:
-          path: /Users/distiller/project/output
+          path: output
       - store_test_results:
-          path: /Users/distiller/project/output/scan
+          path: output/scan
 ```
 
 This will do the following:


### PR DESCRIPTION
* Since we specify working_directory store_artifacts and store_test_results can be relative to that
* You no longer need to cp the report.junit as I've fixed our test results parser to handle `.junit` files

---

**[Recent build showing latest demo config](https://circleci.com/gh/CircleCI-Public/circleci-demo-ios/21#config/containers/0)**

You can also view the full config [here](https://github.com/CircleCI-Public/circleci-demo-ios/blob/master/.circleci/config.yml).

![screenshot from 2018-03-26 19-14-52](https://user-images.githubusercontent.com/277819/37903107-b84bb040-3131-11e8-9bfe-2405f36d80ca.png)
