### PR TITLE
Fix Jenkins link pointing to old docs

### DIFF
--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -34,7 +34,7 @@ If you experience slow launch times of _fastlane_, there are 2 solutions to solv
 
 This is usually caused when running Jenkins as its own user. While this is possible, you'll have to take care of creating a temporary Keychain, filling it and then using it when building your application. 
 
-For more information about the recommended setup with Jenkins open the [Jenkins Guide](https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Jenkins.md).
+For more information about the recommended setup with Jenkins open the [Jenkins Guide](/best-practices/continuous-integration/#jenkins-integration).
 
 ### Code signing issues
 


### PR DESCRIPTION
<!--
Thanks for contributing to _fastlane_! Before you submit your pull request, note that files in the docs folder covering Actions (actions.md and actions/*) and Plugins (available-plugins.md) are auto-generated.
If this is the case, please modify the documentation at their sources (https://github.com/fastlane/fastlane or plugin repository) and will be updated here regularly.
-->
