### PR TITLE
Changing sidenav rule that breaks scrolling

### DIFF
--- a/docs/css/sidenav.css
+++ b/docs/css/sidenav.css
@@ -290,7 +290,7 @@
 }
 
 .wy-grid-for-nav {
-  position: absolute;
+  position: relative;
   width: 100%;
   height: 100%
 }


### PR DESCRIPTION
Every page from Fastlane docs is unscrollable with the touch pad scroll on Chrome 66 on my MacOS. I'm not sure why this is happening but the rule change definitely fixes the behaviour on Google Chrome 66.0.3359.117 on Mac and it doesn't have side-effects AFAIK. It doesn't happen on Sphinx readthedocs theme though.
