### PR TITLE
Fix overflowing tables that contain long code snippets

### DIFF
--- a/docs/css/fabric.css
+++ b/docs/css/fabric.css
@@ -2284,6 +2284,19 @@ input[type="checkbox"][disabled] {
   margin-bottom: 24px
 }
 
+@media screen and (max-width: 768px) {
+  .rst-content table.docutils {
+    display: block;
+    overflow-x: scroll;
+  }
+}
+
+@media screen and (min-width: 769px) {
+  .rst-content table.docutils code {
+    white-space: normal;
+  }
+}
+
 .wy-table caption,
 .rst-content table.docutils caption,
 .rst-content table.field-list caption {


### PR DESCRIPTION
Fixes #601

Before:

![screen shot 2018-05-06 at 20 32 23](https://user-images.githubusercontent.com/5748627/39676067-ac52946a-516c-11e8-85a4-d0c119a33c02.png)

After:

![screen shot 2018-05-06 at 20 33 06](https://user-images.githubusercontent.com/5748627/39676071-b56b5f00-516c-11e8-822e-61d727ad89b8.png)

On mobile, it makes the table scrollable.