### PR TITLE
Additional shell profile file name added

### DIFF
--- a/docs/getting-started/android/setup.md
+++ b/docs/getting-started/android/setup.md
@@ -95,7 +95,7 @@ export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8
 ```
 
-You can find your shell profile at `~/.bashrc`, `~/.bash_profile` or `~/.zshrc` depending on your system. 
+You can find your shell profile at `~/.bashrc`, `~/.bash_profile`, `~/.profile` or `~/.zshrc` depending on your system.
 
 ### Use a Gemfile
 

--- a/docs/getting-started/ios/setup.md
+++ b/docs/getting-started/ios/setup.md
@@ -61,7 +61,7 @@ export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8
 ```
 
-You can find your shell profile at `~/.bashrc`, `~/.bash_profile` or `~/.zshrc` depending on your system. 
+You can find your shell profile at `~/.bashrc`, `~/.bash_profile`, `~/.profile` or `~/.zshrc` depending on your system. 
 
 ### Use a Gemfile
 

--- a/docs/getting-started/ios/setup.md
+++ b/docs/getting-started/ios/setup.md
@@ -61,7 +61,7 @@ export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8
 ```
 
-You can find your shell profile at `~/.bashrc`, `~/.bash_profile`, `~/.profile` or `~/.zshrc` depending on your system. 
+You can find your shell profile at `~/.bashrc`, `~/.bash_profile`, `~/.profile` or `~/.zshrc` depending on your system.
 
 ### Use a Gemfile
 


### PR DESCRIPTION
The shell profile file was called differently for me, therefore I propose adding this name to the docs.

<!--
Thanks for contributing to _fastlane_! Before you submit your pull request, note that files in the docs folder covering Actions (actions.md and actions/*) and Plugins (available-plugins.md) are auto-generated.
If this is the case, please modify the documentation at their sources (https://github.com/fastlane/fastlane or plugin repository) and will be updated here regularly.
-->
