### PR TITLE
Add trailing slash to internal links

### DIFF
--- a/docs/getting-started/android/running-tests.md
+++ b/docs/getting-started/android/running-tests.md
@@ -65,4 +65,4 @@ end
 
 #### Other services
 
-The above example uses Hipchat, but _fastlane_ supports [many other services out there](/actions#notifications). 
+The above example uses Hipchat, but _fastlane_ supports [many other services out there](/actions/#notifications). 

--- a/docs/getting-started/ios/appstore-deployment.md
+++ b/docs/getting-started/ios/appstore-deployment.md
@@ -32,7 +32,7 @@ If everything works, you should have a `[ProductName].ipa` file in the current d
 
 ## Codesigning
 
-Chances are that something went wrong because of code signing at the previous step. We prepared our own [Code Signing Guide](/codesigning/GettingStarted) that helps you setting up the right code signing approach for your project.
+Chances are that something went wrong because of code signing at the previous step. We prepared our own [Code Signing Guide](/codesigning/getting-started/) that helps you setting up the right code signing approach for your project.
 
 # Submitting your app
 

--- a/docs/getting-started/ios/beta-deployment.md
+++ b/docs/getting-started/ios/beta-deployment.md
@@ -32,7 +32,7 @@ If everything works, you should have a `[ProductName].ipa` file in the current d
 
 ## Codesigning
 
-Chances are that something went wrong because of code signing at the previous step. We prepared our own [Code Signing Guide](/codesigning/GettingStarted) that helps you setting up the right code signing approach for your project.
+Chances are that something went wrong because of code signing at the previous step. We prepared our own [Code Signing Guide](/codesigning/getting-started/) that helps you setting up the right code signing approach for your project.
 
 # Uploading your app
 

--- a/docs/getting-started/ios/running-tests.md
+++ b/docs/getting-started/ios/running-tests.md
@@ -90,5 +90,5 @@ error do |ex|
 end
 ```
 
-The above example uses Hipchat, but _fastlane_ supports [many other services out there](/actions#notifications). 
+The above example uses Hipchat, but _fastlane_ supports [many other services out there](/actions/#notifications). 
 

--- a/docs/plugins/create-plugin.md
+++ b/docs/plugins/create-plugin.md
@@ -33,7 +33,7 @@ _fastlane_ is an open platform and we enable every developer to extend it to fit
 
 ### Find a plugin
 
-Head over to [Available Plugins](https://docs.fastlane.tools/plugins/available-plugins) for a list of plugins you can use.
+Head over to [Available Plugins](https://docs.fastlane.tools/plugins/available-plugins/) for a list of plugins you can use.
 
 List all available plugins using
 


### PR DESCRIPTION
Some internal links were missing the trailing slash, requiring an additional and unnecessary redirect for all users using those links. This PR fixes the links I could find.

This PR is additional work for https://github.com/fastlane/docs/issues/643