### PR TITLE
Extract "local actions" into its own file

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -23,7 +23,7 @@ import './path/to/other/Fastfile'
 ```
 
 For _fastlane_ plugins, check out the [available plugins](https://docs.fastlane.tools/plugins/available-plugins/) page.
-If you want to create your own action, check out the [local actions](/create-action#local-actions) page.
+If you want to create your own action, check out the [local actions](/create-action/#local-actions) page.
 
 - [Testing](#testing)
 - [Building](#building)

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -16,7 +16,6 @@ fastlane actions # list all available fastlane actions
 fastlane action [action_name] # more information for a specific action
 ```
 
-<!-- TODO move somewhere more useful -->
 You can import another `Fastfile` by using the `import` action. This is useful if you have shared lanes across multiple apps and you want to store a `Fastfile` in a separate folder. The path must be relative to the `Fastfile` this is called from.
 
 ```ruby

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -16,6 +16,7 @@ fastlane actions # list all available fastlane actions
 fastlane action [action_name] # more information for a specific action
 ```
 
+<!-- TODO move somewhere more useful -->
 You can import another `Fastfile` by using the `import` action. This is useful if you have shared lanes across multiple apps and you want to store a `Fastfile` in a separate folder. The path must be relative to the `Fastfile` this is called from.
 
 ```ruby
@@ -23,6 +24,9 @@ import './path/to/other/Fastfile'
 ```
 
 For _fastlane_ plugins, check out the [available plugins](https://docs.fastlane.tools/plugins/available-plugins) page.
+If you want to create your own action, check out the [local actions](/create-action#local-actions) page.
+
+---
 
 - [Testing](#testing)
 - [Building](#building)

--- a/docs/create-action.md
+++ b/docs/create-action.md
@@ -22,7 +22,3 @@ In general, we might not accept actions that
 - Access the API of a third party service, the third party service should own and maintain the action
 - Complex actions, that will require a lot of work to maintain in the future
 - Everything that isn't mobile developer related
-
-## Extract your action as a fastlane plugin
-
-TODO 

--- a/docs/create-action.md
+++ b/docs/create-action.md
@@ -1,0 +1,28 @@
+# Local actions
+
+You can create your own actions to extend the functionality of fastlane for your project. The action you create will behave exactly like the built in actions.
+
+Just run `fastlane new_action`, enter the name of the action and edit the generated Ruby file in `fastlane/actions/[action_name].rb`. After you finished writing your action, add it to your version control, so it is available for your whole team.
+
+From then on, you can just use your action in your `Fastfile`, just like any other action.
+
+## Submitting the action to the fastlane main repo
+
+Please be aware we may not accept all actions submitted to be bundled with _fastlane_. Before you submit a pull request adding the action to the _fastlane_ code base, submit an issue proposing the new action and why it should be built-in.
+
+In general we tend to accept actions that
+
+- Generally usable for a big majority of developers (e.g. basic interactions with git)
+- Solve pain points for mobile app developers (iOS and Android)
+- have an easy to read documentation and great test coverage
+
+In general, we might not accept actions that
+
+- Solve specific use-cases for only a small subset of developers
+- Access the API of a third party service, the third party service should own and maintain the action
+- Complex actions, that will require a lot of work to maintain in the future
+- Everything that isn't mobile developer related
+
+## Extract your action as a fastlane plugin
+
+TODO 

--- a/docs/plugins/create-plugin.md
+++ b/docs/plugins/create-plugin.md
@@ -4,6 +4,25 @@ The instructions below require _fastlane_ 1.93.0 or higher
 
 _fastlane_ is an open platform and we enable every developer to extend it to fit their needs. That's why we built a plugin system that allows you and your company to provide _fastlane_ plugins to other _fastlane_ users. You have the full power and responsibility of maintaining your plugin and keeping it up to date. This is useful if you maintain your own library or web service, and want to make sure the _fastlane_ plugin is always up to date.
 
+## Local actions
+
+<script type="text/javascript">
+(function () {
+    var anchorMap = {
+        "local-actions": "/create-action/"
+    }
+    var hash = window.location.hash.substring(1);
+    if (hash) {
+        if (anchorMap[hash]) {
+            link = anchorMap[hash] + '#' + hash;
+            window.location.replace(link);
+        }
+    }
+})();
+</script>
+
+This content was moved and now lives [here](/create-action/#local-actions).
+
 ## Find a plugin
 
 Head over to [Available Plugins](https://docs.fastlane.tools/plugins/available-plugins) for a list of plugins you can use.

--- a/docs/plugins/create-plugin.md
+++ b/docs/plugins/create-plugin.md
@@ -2,36 +2,9 @@
 
 The instructions below require _fastlane_ 1.93.0 or higher
 
-## Local actions
-
-You can create your own actions to extend the functionality of fastlane for your project. The action you create will behave exactly like the built in actions.
-
-Just run `fastlane new_action`, enter the name of the action and edit the generated Ruby file in `fastlane/actions/[action_name].rb`. After you finished writing your action, add it to your version control, so it is available for your whole team.
-
-From then on, you can just use your action in your `Fastfile`, just like any other action.
-
-### Submitting the action to the fastlane main repo
-
-Please be aware we may not accept all actions submitted to be bundled with _fastlane_. Before you submit a pull request adding the action to the _fastlane_ code base, submit an issue proposing the new action and why it should be built-in.
-
-In general we tend to accept actions that
-
-- Generally usable for a big majority of developers (e.g. basic interactions with git)
-- Solve pain points for mobile app developers (iOS and Android)
-- have an easy to read documentation and great test coverage
-
-In general, we might not accept actions that
-
-- Solve specific use-cases for only a small subset of developers
-- Access the API of a third party service, the third party service should own and maintain the action
-- Complex actions, that will require a lot of work to maintain in the future
-- Everything that isn't mobile developer related
-
-## Plugins
-
 _fastlane_ is an open platform and we enable every developer to extend it to fit their needs. That's why we built a plugin system that allows you and your company to provide _fastlane_ plugins to other _fastlane_ users. You have the full power and responsibility of maintaining your plugin and keeping it up to date. This is useful if you maintain your own library or web service, and want to make sure the _fastlane_ plugin is always up to date.
 
-### Find a plugin
+## Find a plugin
 
 Head over to [Available Plugins](https://docs.fastlane.tools/plugins/available-plugins) for a list of plugins you can use.
 
@@ -46,7 +19,7 @@ To search for something specific
 fastlane search_plugins [query]
 ```
 
-### Add a plugin to your project
+## Add a plugin to your project
 
 ```no-highlight
 fastlane add_plugin [name]
@@ -61,7 +34,7 @@ This will:
 - Run `fastlane install_plugins` to make sure all required dependencies are installed on your local machine (this step might ask for your admin password to install Ruby gems)
 - You'll have 3 new files, that should all be checked into version control: `Gemfile`, `Gemfile.lock` and `fastlane/Pluginfile`
 
-#### Plugin Source
+### Plugin Source
 
 Your `fastlane/Pluginfile` contains the list of all _fastlane_ plugins your project uses. The `Pluginfile` is a [Gemfile](http://bundler.io/gemfile.html) that gets imported from your main `Gemfile`.
 You specify all dependencies, including the required version numbers:
@@ -83,7 +56,7 @@ gem "fastlane-plugin-xcversion", ">= 1.0"
 
 [More information about a Gemfile](http://bundler.io/gemfile.html)
 
-### Install plugins on another machine
+## Install plugins on another machine
 
 To make sure all plugins are installed on the local machine, run
 
@@ -91,7 +64,7 @@ To make sure all plugins are installed on the local machine, run
 fastlane install_plugins
 ```
 
-### Remove a plugin
+## Remove a plugin
 
 Open your `fastlane/Pluginfile` and remove the line that looks like this
 
@@ -99,7 +72,7 @@ Open your `fastlane/Pluginfile` and remove the line that looks like this
 gem "fastlane-plugin-[plugin_name]"
 ```
 
-### Create your own plugin
+## Create your own plugin
 
 ```no-highlight
 cd ~/new/folder/
@@ -111,7 +84,7 @@ fastlane new_plugin [plugin_name]
 - Edit the `lib/fastlane/plugin/[plugin_name]/actions/[plugin_name].rb` and implement your action
 - Easily test the plugin locally by running `fastlane add_plugin` in your project's directory and specifying the local path when asked for it
 
-##### New plugin for existing gem
+#### New plugin for existing gem
 
 If you already have an existing gem you want to provide a _fastlane_ plugin for, you'll still have to create a new Ruby gem. The reason for that is the way plugins are imported.
 
@@ -123,9 +96,9 @@ All you have to do if you have an existing gem:
 - `fastlane new_plugin [plugin_name]`
 - Inside the newly created folder, edit the `fastlane-plugin-[plugin_name].gemspec` and add your gem as a dependency. It is recommended to also specify a version number requirement
 
-#### Publishing your plugin
+### Publishing your plugin
 
-##### RubyGems
+#### RubyGems
 
 The recommended way to publish your plugin is to publish it on [RubyGems.org](https://rubygems.org). Follow the steps below to publish your plugin.
 
@@ -141,7 +114,7 @@ rake release
 
 Now all your users can run `fastlane add_plugin [plugin_name]` to install and use your plugin.
 
-##### GitHub
+#### GitHub
 
 If for some reason you don't want to use RubyGems, you can also make your plugin available on GitHub. Your users then need to add the following to the `Pluginfile`
 
@@ -149,8 +122,8 @@ If for some reason you don't want to use RubyGems, you can also make your plugin
 gem "fastlane-plugin-[plugin_name]", git: "https://github.com/[user]/[plugin_name]"
 ```
 
-### Advanced
+## Advanced
 
-#### Multiple actions in one plugin
+### Multiple actions in one plugin
 
 Let's assume you work on a _fastlane_ plugin for project management software. You could call it `fastlane-plugin-pm` and it may contain any number of actions and helpers, just add them to your `actions` folder. Make sure to mention the available actions in your plugin's `README.md`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,8 +34,8 @@ pages:
     - Beta Deployment: getting-started/android/beta-deployment.md
     - Release Deployment: getting-started/android/release-deployment.md
 - Actions: 
-  - Build-in actions: actions.md
-  - Local actions: local-actions.md
+  - Available Actions: actions.md
+  - Create Your Own Action: create-action.md
 - _Actions:
   - adb: actions/adb.md
   - adb_devices: actions/adb_devices.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,7 +33,9 @@ pages:
     - Screenshots: getting-started/android/screenshots.md
     - Beta Deployment: getting-started/android/beta-deployment.md
     - Release Deployment: getting-started/android/release-deployment.md
-- Actions: actions.md
+- Actions: 
+  - Build-in actions: actions.md
+  - Local actions: local-actions.md
 - _Actions:
   - adb: actions/adb.md
   - adb_devices: actions/adb_devices.md


### PR DESCRIPTION
This PR extracts a section from the "Create plugin" file that concerns local actions into its own file.
It moves the Actions list to an "Available Actions" navigation entry.
The old headline-anchor is redirected to the new location and a link to the new location is added under the old headline.

closes #394 