### PR TITLE
Fix two typos in sync_code_signing.md decryption

### DIFF
--- a/docs/actions/sync_code_signing.md
+++ b/docs/actions/sync_code_signing.md
@@ -346,7 +346,7 @@ Decrypt your cert found in `certs/<type>/<unique-id>.cer` as a pem file:
 
 ```no-highlight
 openssl aes-256-cbc -k "<password>" -in "certs/<type>/<unique-id>.cer" -out "cert.dem" -a -d
-openssl x509 -inform der -in cert.der -out cert.pem
+openssl x509 -inform der -in cert.dem -out cert.pem
 ```
 
 Decrypt your private key found in `certs/<type>/<unique-id>.p12` as a pem file:
@@ -358,7 +358,7 @@ openssl aes-256-cbc -k "<password>" -in "certs/distribution/<unique-id>.p12" -ou
 Generate an encrypted p12 file with the same or new password:
 
 ```no-highlight
-openssl pkcs12 -export -out "cert.p12" -inkey "key.pem' -in "cert.pem" -password pass:<password>
+openssl pkcs12 -export -out "cert.p12" -inkey "key.pem" -in "cert.pem" -password pass:<password>
 ```
 
 ## Is this secure?


### PR DESCRIPTION
The example commands to decrypt the cert and generate an encrypted p12 are now self-consistent.

<!--
Thanks for contributing to _fastlane_! Before you submit your pull request, note that files in the docs folder covering Actions (actions.md and actions/*) and Plugins (available-plugins.md) are auto-generated.
If this is the case, please modify the documentation at their sources (https://github.com/fastlane/fastlane or plugin repository) and will be updated here regularly.
-->

I'm not sure if this documentation is autogenerated from source elsewhere.