### PR TITLE
Fastfile: Remove `opt_out_crash_reporting` as it is not supported any more

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,5 +1,4 @@
 # since we don't want to influence our own stats
-opt_out_crash_reporting
 opt_out_usage
 
 lane :test do |options|


### PR DESCRIPTION
Currently you get this output:
```
[14:55:24]: -------------------------------------
[14:55:24]: --- Step: opt_out_crash_reporting ---
[14:55:24]: -------------------------------------
==========================================
This action (opt_out_crash_reporting) is deprecated
==========================================

[14:55:24]: fastlane doesn't have crash reporting any more, feel free to remove `opt_out_crash_reporting` from your Fastfile
```

After this change, you don't any more.