### PR TITLE
Document parameters for fastlane command line tools

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1230,3 +1230,14 @@ In particular:
   action, such as: `other_action.git_add`, `other_action.git_commit`.
 - Think twice before calling an action from another action. There is often a better
   solution.
+
+## Passing parameters to _fastlane_ command line tools
+
+_fastlane_ contains several command line tools, e.g. [`fastlane deliver`](/actions/deliver/) or [`fastlane snapshot`](/actions/snapshot/). To pass parameters to these tools, append the option names and values as you would for a normal shell command:
+
+```shell
+fastlane [tool] --[option]=[value]
+
+fastlane deliver --skip_screenshots=true
+fastlane snapshot --screenshots_path=xxxxx --schema=xxxx
+```


### PR DESCRIPTION
Needed to uses `bundle exec fastlane deliver --skip_screenshots=true` to solve my specific problem, couldn't find any documentation how to pass parameters to tools on the command line. Unsurprisingly it's how you usually would do things, but as I almost never use CLIs, this was still new to me.