### PR TITLE
Fixed latest version of screengrab gradle package

### DIFF
--- a/docs/getting-started/android/screenshots.md
+++ b/docs/getting-started/android/screenshots.md
@@ -47,7 +47,7 @@ Add the test dependency to your Gradle build:
 androidTestCompile 'tools.fastlane:screengrab:x.x.x'
 ```
 
-The latest version can be determined by visiting the [_screengrab_ RubyGems page](https://rubygems.org/gems/screengrab)
+The latest version is [ ![Download](https://api.bintray.com/packages/fastlane/fastlane/screengrab/images/download.svg) ](https://bintray.com/fastlane/fastlane/screengrab/_latestVersion)
 
 ### Configuring your Manifest Permissions
 Ensure that the following permissions exist in your `src/debug/AndroidManifest.xml`


### PR DESCRIPTION
Latest version of Gradle Dependency for screengrab was wrong at [_screengrab_ RubyGems page](https://rubygems.org/gems/screengrab). It shows 1.0.0 right now but it's more up to date on bintray:  [ ![Download](https://api.bintray.com/packages/fastlane/fastlane/screengrab/images/download.svg) ](https://bintray.com/fastlane/fastlane/screengrab/_latestVersion) So I've changed it to look exactly the same on `screengrab` docs

<!--
Thanks for contributing to _fastlane_! Before you submit your pull request, note that files in the docs folder covering Actions (actions.md and actions/*) and Plugins (available-plugins.md) are auto-generated.
If this is the case, please modify the documentation at their sources (https://github.com/fastlane/fastlane or plugin repository) and will be updated here regularly.
-->
