### PR TITLE
Docs: add instructions how to build APKs for screengrab via lane

### DIFF
--- a/docs/getting-started/android/screenshots.md
+++ b/docs/getting-started/android/screenshots.md
@@ -125,7 +125,20 @@ You can use [QuickDemo](https://github.com/PSPDFKit-labs/QuickDemo) to clean up 
 
 ## Generating Screenshots with Screengrab
 
-- Run `./gradlew assembleDebug assembleAndroidTest` to generate debug and test APKs
+- Run `./gradlew assembleDebug assembleAndroidTest` manually to generate debug and test APKs
+  - You can also create a lane and use `build_android_app`:
+    ```ruby
+    desc "Build debug and test APK for screenshots"
+    lane :buildForScreengrab do
+      build_android_app(
+        task: 'assemble',
+        build_type: 'Debug'
+      )
+      build_android_app(
+        task: 'assemble',
+        build_type: 'AndroidTest'
+      )
+    end
 - Run `fastlane screengrab` in your app project directory to generate screenshots
   - You will be prompted to provide any required parameters which are not in your `Screengrabfile`, or provided as command line arguments
 - Your screenshots will be saved to `fastlane/metadata/android` in the directory where you ran `fastlane screengrab`

--- a/docs/getting-started/android/screenshots.md
+++ b/docs/getting-started/android/screenshots.md
@@ -129,7 +129,10 @@ You can use [QuickDemo](https://github.com/PSPDFKit-labs/QuickDemo) to clean up 
   - You can also create a lane and use `build_android_app`:
     ```ruby
     desc "Build debug and test APK for screenshots"
-    lane :buildForScreengrab do
+    lane :build_for_screengrab do
+      gradle(
+        task: 'clean'
+      )
       build_android_app(
         task: 'assemble',
         build_type: 'Debug'


### PR DESCRIPTION
No reason why people have to build this manually, the old way. 
We have an action that does the exact same thing.

Related https://github.com/fastlane/fastlane/pull/13161