### PR TITLE
Updates docs to indicate symbol is returned

### DIFF
--- a/docs/advanced/lanes.md
+++ b/docs/advanced/lanes.md
@@ -174,7 +174,7 @@ end
 It can be useful to dynamically access properties of the current lane. These are available in `lane_context`:
 
 ```ruby
-lane_context[SharedValues::PLATFORM_NAME]        # Platform name, e.g. `ios`, `android` or empty (for root level lanes)
+lane_context[SharedValues::PLATFORM_NAME]        # Platform name, e.g. `:ios`, `:android` or empty (for root level lanes)
 lane_context[SharedValues::LANE_NAME]            # The name of the current lane preceded by the platform name (stays the same when switching lanes)
 lane_context[SharedValues::DEFAULT_PLATFORM]     # Default platform
 ```


### PR DESCRIPTION
Updates docs regarding `lane_context[SharedValues::PLATFORM_NAME]` to denote that it returns a symbol and not a string.