### PR TITLE
Fix test_sample_code to use ConfigItem methods for ensuring valid values

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/fastlane/fastlane
-  revision: e8338d467f90071fc3fea30e259688e76055b7dd
+  revision: 7efc89a6679452cec4f72f006dbb3577c8f5efb8
   specs:
-    fastlane (2.104.0)
+    fastlane (2.105.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.3, < 3.0.0)
       babosa (>= 1.0.2, < 2.0.0)
@@ -78,7 +78,7 @@ GEM
     dotenv (2.5.0)
     emoji_regex (0.1.1)
     excon (0.62.0)
-    faraday (0.15.2)
+    faraday (0.15.3)
       multipart-post (>= 1.2, < 3)
     faraday-cookie_jar (0.0.6)
       faraday (>= 0.7.4)
@@ -87,10 +87,10 @@ GEM
       faraday (~> 0.8)
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
-    fastimage (2.1.3)
+    fastimage (2.1.4)
     gh_inspector (1.1.3)
     git (1.5.0)
-    google-api-client (0.23.8)
+    google-api-client (0.23.9)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.5, < 0.7.0)
       httpclient (>= 2.8.1, < 3.0)
@@ -156,7 +156,7 @@ GEM
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
     security (0.1.3)
-    signet (0.9.1)
+    signet (0.9.2)
       addressable (~> 2.3)
       faraday (~> 0.9)
       jwt (>= 1.5, < 3.0)

--- a/fastlane/actions/test_sample_code.rb
+++ b/fastlane/actions/test_sample_code.rb
@@ -61,8 +61,14 @@ module Fastlane
             config_item = available_options.find { |a| a.key == current_argument }
             UI.user_error!("Unknown parameter '#{current_argument}' for action '#{method_sym}'") if config_item.nil?
 
-            if config_item.data_type && !value.kind_of?(config_item.data_type) && !config_item.optional && !config_item.skip_type_validation
-              UI.user_error!("'#{current_argument}' value must be a #{config_item.data_type}! Found #{value.class} instead.")
+            if value.nil? && config_item.optional
+              next
+            end
+
+            if config_item.data_type == Fastlane::Boolean
+              config_item.ensure_boolean_type_passes_validation(value)
+            else
+              config_item.ensure_generic_type_passes_validation(value)
             end
           end
         else


### PR DESCRIPTION
The docs counterpart to https://github.com/fastlane/fastlane/pull/13391

## Problem
Can't release because the docs implementation of `test_sample_code` needed to updated like the fastlane implementation of `test_sample_code that was changed in https://github.com/fastlane/fastlane/pull/13391

## Solution
Do the same change :rocket: