### PR TITLE
Update flutter guide title and URL

### DIFF
--- a/docs/getting-started/cross-platform/flutter.md
+++ b/docs/getting-started/cross-platform/flutter.md
@@ -2,4 +2,4 @@
 
 Most of the _fastlane_ docs on this page apply to Flutter projects as well. 
 
-To get started, the Flutter team wrote an excellent official guide on [How to get started with fastlane for Flutter](https://flutter.io/fastlane-cd/).
+To get started, the Flutter team wrote an excellent official guide on [Continuous Delivery using fastlane with Flutter](https://flutter.io/docs/deployment/fastlane-cd).


### PR DESCRIPTION
Guide at Flutter website seems to have moved and gotten a new title.