### PR TITLE
Apple forcing 2FA disables solution proposed on Best Practices » Continuous Integration

### DIFF
--- a/docs/best-practices/continuous-integration.md
+++ b/docs/best-practices/continuous-integration.md
@@ -20,16 +20,7 @@ Multiple CI products and services offer integrations with fastlane:
 
 ### Separate Apple ID for CI
 
-The easiest way to get _fastlane_ running on a CI system is to create a separate Apple ID that doesn't have 2-factor auth enabled, with a long, randomly generated password. Additionally make sure the newly created Apple account has limited access to only the apps and resources it needs.
-
-There are multiple reasons on why this approach is much easier:
-
-- An Apple ID session is only valid for a certain region, meaning if your CI system is in a different region than your local machine, you'll run into issues
-- An Apple ID session is only valid for up to a month, meaning you'll have to generate a new session every month. Usually you'd only know about it when your build starts failing
-
-There is nothing _fastlane_ can do better in that regard, as these are technical limitations on how App Store Connect sessions are handled.
-
-Creating a separate Apple ID allows you to limit the permission scope, have a randomly generated password, and will make it much easier for you to set up CI using _fastlane_.
+As of February 27th 2019, Apple is enforcing 2FA on developer Apple ID's thus disabling the option to create a separate Apple ID specifically for CI without 2FA. 
 
 ### Security code and session
 


### PR DESCRIPTION
![2famail](https://user-images.githubusercontent.com/14804033/52750910-522c9c80-2fcc-11e9-93ef-280349c02480.png)

The best practices on continuous integration docs recommend creating a new Apple ID without 2FA enabled when submitting builds from CI. This approach will no longer work on February 27th, 2019 since Apple will enforce 2FA on developers Apple ID. The docs should be updated to remove this recommendation once 2FA is obligatory.

I'd update the docs but I'm not sure what's the recommended setup when 