### PR TITLE
Update CI/2FA docs

### DIFF
--- a/docs/best-practices/continuous-integration.md
+++ b/docs/best-practices/continuous-integration.md
@@ -27,7 +27,7 @@ Creating a separate Apple ID allows you to limit the permission scope, have a ra
 
 ### Security code and session
 
-When your Apple account has 2 Factor Authentication (or 2 step verification) enabled, you will be asked to verify your identity by entering a security code. If you already have a trusted device configured for your account, then the code will appear on the device. If you don't have any devices configured, but have trusted a phone number, then the code will be sent to your phone. The resulting session will be stored in `~/.fastlane/spaceship/[email]/cookie`. The session should be valid for about one month, however there is no way to test this without actually waiting for over a month.
+When your Apple account has 2-factor authentication (or 2-step verification) enabled, you will be asked to verify your identity by entering a security code. If you already have a trusted device configured for your account, then the code will appear on the device. If you don't have any devices configured, but have trusted a phone number, then the code will be sent to your phone. The resulting session will be stored in `~/.fastlane/spaceship/[email]/cookie`. The session should be valid for about one month, however there is no way to test this without actually waiting for over a month.
 
 ### Use of application specific passwords and `spaceauth`
 

--- a/docs/best-practices/continuous-integration.md
+++ b/docs/best-practices/continuous-integration.md
@@ -27,7 +27,10 @@ Several Fastlane actions communicate with Apple services that need authenticatio
 
 ### Separate Apple ID for CI
 
-The easiest way to get _fastlane_ running on a CI system is to create a separate Apple ID that doesn't have 2-factor authentication enabled.
+The easiest way to get _fastlane_ running on a CI system is to create a separate Apple ID that 
+
+  - doesn't have 2-factor authentication enabled.
+  - doesn't have the Account Holder role
 
 Creating a separate Apple ID allows you to limit the permission scope (limited access to only the apps and resources it needs), have a long, randomly generated password, and will make it much more convenient for you to set up CI using _fastlane_.
 

--- a/docs/best-practices/continuous-integration.md
+++ b/docs/best-practices/continuous-integration.md
@@ -35,25 +35,29 @@ When you can not enter this token, as on a Continuous Integration system, you ha
 
 #### Application specific passwords
 
-If you want to upload builds to TestFlight / App Store Connect from your CI machine, you need to generate an application specific password:
+If you want to upload builds to App Store Connect (actions `deliver` or `upload_to_app_store`) or TestFlight (actions `pilot`, `testflight` or `upload_to testflight`) from your CI machine, you need to generate an application specific password:
 
 1. Visit [appleid.apple.com/account/manage](https://appleid.apple.com/account/manage)
 1. Generate a new application specific password
 1. Provide the application specific password using the environment variable `FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD`
 
+This will supply the application specific password to iTMSTransporter, the tool used by those actions to perform the upload.
+
 #### `spaceauth`
 
-Because your CI machine will not be able to prompt you for your two-step or two-factor auth information, you also need to generate a login session for your CI machine in advance. You can get on your local machine this by running:
+All the other actions interacting with Apple's APIs unfortunately do not accept application specific passwords.
+
+As your CI machine will not be able to prompt you for your two-factor authentication or two-step verification information, you need to generate a login session for Apple ID  in advance. You can get on your local machine this by running:
 
 ```
 fastlane spaceauth -u user@email.com
 ```
 
-This will generate a token you can set using the `FASTLANE_SESSION` environment variable on your CI system.
+This will generate a token you can set using the `FASTLANE_SESSION` environment variable on your CI system. This session will be reused instead of triggering a new login each time _fastlane_ communicates with Apple's APIs.
 
 Please note:
 
-- An Apple ID session is only valid for a certain region, meaning if your CI system is in a different region than your local machine, you'll run into issues
+- An Apple ID session is only valid for a certain region, meaning if your CI system is in a different region than your local machine, you might run into issues
 - An Apple ID session is only valid for up to a month, meaning you'll have to generate a new session every month. Usually you'd only know about it when your build starts failing
 
 There is nothing _fastlane_ can do better in that regard, as these are technical limitations on how App Store Connect sessions are handled.

--- a/docs/best-practices/continuous-integration.md
+++ b/docs/best-practices/continuous-integration.md
@@ -29,7 +29,7 @@ Several Fastlane actions communicate with Apple services that need authenticatio
 
 The easiest way to get _fastlane_ running on a CI system is to create a separate Apple ID that 
 
-  - doesn't have 2-factor authentication enabled.
+  - doesn't have 2-factor authentication enabled
   - doesn't have the Account Holder role
 
 Creating a separate Apple ID allows you to limit the permission scope (limited access to only the apps and resources it needs), have a long, randomly generated password, and will make it much more convenient for you to set up CI using _fastlane_.

--- a/docs/best-practices/continuous-integration.md
+++ b/docs/best-practices/continuous-integration.md
@@ -23,7 +23,7 @@ Multiple CI products and services offer integrations with fastlane:
 
 ## Authentication with Apple services
 
-Several Fastlane actions communicate with Apple services that need authentication. This can post several challenges on CI:
+Several Fastlane actions communicate with Apple services that need authentication. This can pose several challenges on CI:
 
 ### Separate Apple ID for CI
 

--- a/docs/best-practices/continuous-integration.md
+++ b/docs/best-practices/continuous-integration.md
@@ -61,7 +61,7 @@ This will supply the application specific password to iTMSTransporter, the tool 
 
 All other actions interacting with Apple's APIs do not accept application specific passwords.
 
-As your CI machine will not be able to prompt you for your two-factor authentication or two-step verification information, you need to generate a login session for Apple ID  in advance. You can get on your local machine this by running:
+As your CI machine will not be able to prompt you for your two-factor authentication or two-step verification information, you need to generate a login session for Apple ID in advance. You can get on your local machine this by running:
 
 ```
 fastlane spaceauth -u user@email.com

--- a/docs/best-practices/continuous-integration.md
+++ b/docs/best-practices/continuous-integration.md
@@ -35,7 +35,7 @@ Creating a separate Apple ID allows you to limit the permission scope (limited a
 
 _fastlane_ fully supports [2-factor authentication (2FA)](https://support.apple.com/en-us/HT204915) (and legacy [2-step verification (2SV)](https://support.apple.com/en-us/HT204152)) for logging in to your Apple ID and Apple Developer account. 🌟
 
-Note: Apple announced that as of February 27th 2019, it is enforcing 2-factor authentication on developer Apple IDs with the "Account Owner" role.
+Note: [Apple announced that as of February 27th 2019](https://developer.apple.com/news/?id=02202019a), it is enforcing 2-factor authentication on developer Apple IDs with the "Account Holder" role.
 
 #### Security code and session
 

--- a/docs/best-practices/continuous-integration.md
+++ b/docs/best-practices/continuous-integration.md
@@ -4,7 +4,7 @@
 
 _fastlane_ works very well in Continuous Integration setups. It for example automatically generates a JUnit report for you that allows Continuous Integration systems, like `Jenkins`, access the results of your deployment.
 
-- [Intergrations](#integrations)
+- [Integrations](#integrations)
 - [Authentication with Apple services](#authentication-with-apple-services)
 - [Environment variables to set](#environment-variables-to-set)
 - [Deploy Strategy](#deploy-strategy)

--- a/docs/best-practices/continuous-integration.md
+++ b/docs/best-practices/continuous-integration.md
@@ -18,7 +18,7 @@ Multiple CI products and services offer integrations with fastlane:
 
 ## Two-step or Two-factor auth
 
-Fastlane fully support 2 step verification and 2 Factor Authentication for logging in to your Apple ID and Apple Developer account.
+_fastlane_ fully supports 2-step verification and 2-factor authentication for logging in to your Apple ID and Apple Developer account. 🌟
 
 
 The easiest way to get _fastlane_ running on a CI system is to create a separate Apple ID that doesn't have 2-factor auth enabled, with a long, randomly generated password. Additionally make sure the newly created Apple account has limited access to only the apps and resources it needs.

--- a/docs/best-practices/continuous-integration.md
+++ b/docs/best-practices/continuous-integration.md
@@ -4,6 +4,11 @@
 
 _fastlane_ works very well in Continuous Integration setups. It for example automatically generates a JUnit report for you that allows Continuous Integration systems, like `Jenkins`, access the results of your deployment.
 
+- [Intergrations](#integrations)
+- [Authentication with Apple services](#authentication-with-apple-services)
+- [Environment variables to set](#environment-variables-to-set)
+- [Deploy Strategy](#deploy-strategy)
+
 ## Integrations
 
 Multiple CI products and services offer integrations with fastlane:
@@ -16,26 +21,35 @@ Multiple CI products and services offer integrations with fastlane:
 - [Azure DevOps](/best-practices/continuous-integration/azure-devops/) (formerly known as: Visual Studio Team Services)
 - [NeverCode](/best-practices/continuous-integration/nevercode/)
 
-## Two-step or Two-factor auth
+## Authentication with Apple services
 
-_fastlane_ fully supports 2-step verification and 2-factor authentication for logging in to your Apple ID and Apple Developer account. 🌟
+Several Fastlane actions communicate with Apple services that need authentication. This can post several challenges on CI:
 
+### Separate Apple ID for CI
 
-The easiest way to get _fastlane_ running on a CI system is to create a separate Apple ID that doesn't have 2-factor auth enabled, with a long, randomly generated password. Additionally make sure the newly created Apple account has limited access to only the apps and resources it needs.
+The easiest way to get _fastlane_ running on a CI system is to create a separate Apple ID that doesn't have 2-factor authentication enabled.
 
-Creating a separate Apple ID allows you to limit the permission scope, have a randomly generated password, and will make it much easier for you to set up CI using _fastlane_.
+Creating a separate Apple ID allows you to limit the permission scope (limited access to only the apps and resources it needs), have a long, randomly generated password, and will make it much more convenient for you to set up CI using _fastlane_.
 
-### Security code and session
+### Two-step or Two-factor auth
 
-When your Apple account has 2-factor authentication (or 2-step verification) enabled, you will be asked to verify your identity by entering a security code. If you already have a trusted device configured for your account, then the code will appear on the device. If you don't have any devices configured, but have trusted a phone number, then the code will be sent to your phone. The resulting session will be stored in `~/.fastlane/spaceship/[email]/cookie`. The session should be valid for about one month, however there is no way to test this without actually waiting for over a month.
+_fastlane_ fully supports [2-factor authentication (2FA)](https://support.apple.com/en-us/HT204915) (and legacy [2-step verification (2SV)](https://support.apple.com/en-us/HT204152)) for logging in to your Apple ID and Apple Developer account. 🌟
 
-### Use of application specific passwords and `spaceauth`
+Note: Apple announced that as of February 27th 2019, it is enforcing 2-factor authentication on developer Apple IDs with the "Account Owner" role.
 
-When you can not enter this token, as on a Continuous Integration system, you have to use other ways to log in:
+#### Security code and session
 
-#### Application specific passwords
+When your Apple account has 2-factor authentication (or 2-step verification) enabled, you will be asked to verify your identity by entering a security code. If you already have a trusted device configured for your account, then the code will appear on the device. If you don't have any devices configured, but have trusted a phone number, then the code will be sent to your phone. 
 
-If you want to upload builds to App Store Connect (actions `deliver` or `upload_to_app_store`) or TestFlight (actions `pilot`, `testflight` or `upload_to testflight`) from your CI machine, you need to generate an application specific password:
+The resulting session will be stored in `~/.fastlane/spaceship/[email]/cookie`, which should be valid for about one month.
+
+#### Use of application specific passwords and `spaceauth`
+
+When you can not enter the security code manually, as on a Continuous Integration system, you have to use other ways to log in:
+
+##### Application specific passwords
+
+If you want to upload builds to App Store Connect (actions `upload_to_app_store` and `deliver`) or TestFlight (actions `upload_to testflight`, `pilot` or `testflight`) from your CI machine, you need to generate an _application specific password_:
 
 1. Visit [appleid.apple.com/account/manage](https://appleid.apple.com/account/manage)
 1. Generate a new application specific password
@@ -43,9 +57,9 @@ If you want to upload builds to App Store Connect (actions `deliver` or `upload_
 
 This will supply the application specific password to iTMSTransporter, the tool used by those actions to perform the upload.
 
-#### `spaceauth`
+##### `spaceauth`
 
-All the other actions interacting with Apple's APIs unfortunately do not accept application specific passwords.
+All other actions interacting with Apple's APIs do not accept application specific passwords.
 
 As your CI machine will not be able to prompt you for your two-factor authentication or two-step verification information, you need to generate a login session for Apple ID  in advance. You can get on your local machine this by running:
 
@@ -53,18 +67,14 @@ As your CI machine will not be able to prompt you for your two-factor authentica
 fastlane spaceauth -u user@email.com
 ```
 
-This will generate a token you can set using the `FASTLANE_SESSION` environment variable on your CI system. This session will be reused instead of triggering a new login each time _fastlane_ communicates with Apple's APIs.
+The generated value then has to be stored inside the `FASTLANE_SESSION` environment variable on your CI system. This session will be reused instead of triggering a new login each time _fastlane_ communicates with Apple's APIs.
 
 Please note:
 
 - An Apple ID session is only valid for a certain region, meaning if your CI system is in a different region than your local machine, you might run into issues
 - An Apple ID session is only valid for up to a month, meaning you'll have to generate a new session every month. Usually you'd only know about it when your build starts failing
 
-There is nothing _fastlane_ can do better in that regard, as these are technical limitations on how App Store Connect sessions are handled.
-
-### Separate Apple ID for CI
-
-Apple announced that as of February 27th 2019, it is enforcing 2FA on developer Apple IDs thus disabling the option to create a separate Apple ID specifically for CI without 2FA. If you somehow still have an Apple ID that does not have 2 Factor Authentication enabled, you can of course use that one to login via _fastlane_.
+Unfortunately there is nothing _fastlane_ can do better in this regard, as these are technical limitations on how App Store Connect sessions are handled.
 
 ## Environment variables to set
 
@@ -73,7 +83,8 @@ Most setups will need the following environment variables
 - `FASTLANE_USER`: Your App Store Connect / Apple Developer Portal user, if your _fastlane_ setup accesses App Store Connect or the Apple Developer Portal (e.g. submit a TestFlight build, create a profile, ...)
 - `FASTLANE_PASSWORD`: Your App Store Connect / Apple Developer Portal password, usually only needed if you also set the `FASTLANE_USER` variable
 - `MATCH_PASSWORD`: You need to provide the password of your _match_ encryption if you use _match_
-- `FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD`: You need to provide an [application specific password](#two-step-or-two-factor-auth) if you have 2-factor enabled and use _pilot_ or _deliver_ to upload a binary to App Store Connect
+- `FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD`: You need to provide an [application specific password](#application-specific-passwords) if you have 2-factor enabled and use _pilot_ or _deliver_ to upload a binary to App Store Connect
+- `FASTLANE_SESSION`: You need to provide a [pregenerated session via `fastlane spaceauth`](#spaceauth) if you have 2-factor authentication enabled and want to use any actions that communicates with App Store Connect.
 - `LANG` and `LC_ALL`: These set up the locale your shell and all the commands you execute run at. _fastlane_ needs these to be set to an UTF-8 locale to work correctly, for example `en_US.UTF-8`. Many CI systems come with a locale that is unset or set to ASCII by default, so make sure to double-check whether yours is set correctly.
 
 ## Deploy Strategy
@@ -114,7 +125,7 @@ You can set up your own ```Release``` job, which is only triggered manually.
 })();
 </script>
 
-The following content was moved:
+The following tool and service specific content was moved:
 
 #### Jenkins Integration
 

--- a/docs/best-practices/continuous-integration.md
+++ b/docs/best-practices/continuous-integration.md
@@ -18,26 +18,22 @@ Multiple CI products and services offer integrations with fastlane:
 
 ## Two-step or Two-factor auth
 
-### Separate Apple ID for CI
+Fastlane fully support 2 step verification and 2 Factor Authentication for logging in to your Apple ID and Apple Developer account.
+
 
 The easiest way to get _fastlane_ running on a CI system is to create a separate Apple ID that doesn't have 2-factor auth enabled, with a long, randomly generated password. Additionally make sure the newly created Apple account has limited access to only the apps and resources it needs.
-
-There are multiple reasons on why this approach is much easier:
-
-- An Apple ID session is only valid for a certain region, meaning if your CI system is in a different region than your local machine, you'll run into issues
-- An Apple ID session is only valid for up to a month, meaning you'll have to generate a new session every month. Usually you'd only know about it when your build starts failing
-
-There is nothing _fastlane_ can do better in that regard, as these are technical limitations on how App Store Connect sessions are handled.
 
 Creating a separate Apple ID allows you to limit the permission scope, have a randomly generated password, and will make it much easier for you to set up CI using _fastlane_.
 
 ### Security code and session
 
-When your Apple account has 2-factor or 2-step auth enabled, you'll be asked to verify your identity by entering a security code. If you already have a trusted device configured for your account, then the code will appear on the device. If you don't have any devices configured, but have trusted a phone number, then the code will be sent to your phone. The resulting session will be stored in `~/.fastlane/spaceship/[email]/cookie`. Again, the session should be valid for about one month, however there is no way to test this without actually waiting for over a month.
+When your Apple account has 2 Factor Authentication (or 2 step verification) enabled, you will be asked to verify your identity by entering a security code. If you already have a trusted device configured for your account, then the code will appear on the device. If you don't have any devices configured, but have trusted a phone number, then the code will be sent to your phone. The resulting session will be stored in `~/.fastlane/spaceship/[email]/cookie`. The session should be valid for about one month, however there is no way to test this without actually waiting for over a month.
 
 ### Use of application specific passwords and `spaceauth`
 
-Before going through this guide, make sure to read the section above.
+When you can not enter this token, as on a Continuous Integration system, you have to use other ways to log in:
+
+#### Application specific passwords
 
 If you want to upload builds to TestFlight / App Store Connect from your CI machine, you need to generate an application specific password:
 
@@ -45,7 +41,9 @@ If you want to upload builds to TestFlight / App Store Connect from your CI mach
 1. Generate a new application specific password
 1. Provide the application specific password using the environment variable `FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD`
 
-Because your CI machine will not be able to prompt you for your two-step or two-factor auth information, you also need to generate a login session for your CI machine in advance. You can get this by running:
+#### `spaceauth`
+
+Because your CI machine will not be able to prompt you for your two-step or two-factor auth information, you also need to generate a login session for your CI machine in advance. You can get on your local machine this by running:
 
 ```
 fastlane spaceauth -u user@email.com
@@ -53,14 +51,16 @@ fastlane spaceauth -u user@email.com
 
 This will generate a token you can set using the `FASTLANE_SESSION` environment variable on your CI system.
 
-### Bypass trusted device and use SMS for verification
+Please note:
 
-If you have a trusted device configured, Apple will not send a SMS code to your phone for your Apple account when you try to generate a web session with _fastlane_. Instead, a code will be displayed on one of your account's trusted devices. This can be problematic if you are trying to authenticate but don't have access to a trusted device. Take the following steps to circumvent the device and use SMS instead:
+- An Apple ID session is only valid for a certain region, meaning if your CI system is in a different region than your local machine, you'll run into issues
+- An Apple ID session is only valid for up to a month, meaning you'll have to generate a new session every month. Usually you'd only know about it when your build starts failing
 
-- Attempt to generate a web session with `fastlane spaceauth -u [email]` and wait for security code prompt to appear
-- Open a browser to [appleid.apple.com](https://appleid.apple.com) or an address that requires you to login with your Apple ID, and logout of any previous session
-- Login with your Apple ID and request a code be sent to the desired phone when prompted for a security code
-- Use the code sent to phone with _fastlane_ instead of with the browser
+There is nothing _fastlane_ can do better in that regard, as these are technical limitations on how App Store Connect sessions are handled.
+
+### Separate Apple ID for CI
+
+Apple announced that as of February 27th 2019, it is enforcing 2FA on developer Apple ID's thus disabling the option to create a separate Apple ID specifically for CI without 2FA. If you somehow still have an Apple ID that does not have 2 Factor Authentication enabled, you can of course use that one to login via _fastlane_.
 
 ## Environment variables to set
 

--- a/docs/best-practices/continuous-integration.md
+++ b/docs/best-practices/continuous-integration.md
@@ -60,7 +60,7 @@ There is nothing _fastlane_ can do better in that regard, as these are technical
 
 ### Separate Apple ID for CI
 
-Apple announced that as of February 27th 2019, it is enforcing 2FA on developer Apple ID's thus disabling the option to create a separate Apple ID specifically for CI without 2FA. If you somehow still have an Apple ID that does not have 2 Factor Authentication enabled, you can of course use that one to login via _fastlane_.
+Apple announced that as of February 27th 2019, it is enforcing 2FA on developer Apple IDs thus disabling the option to create a separate Apple ID specifically for CI without 2FA. If you somehow still have an Apple ID that does not have 2 Factor Authentication enabled, you can of course use that one to login via _fastlane_.
 
 ## Environment variables to set
 

--- a/docs/best-practices/continuous-integration.md
+++ b/docs/best-practices/continuous-integration.md
@@ -125,7 +125,7 @@ You can set up your own ```Release``` job, which is only triggered manually.
 })();
 </script>
 
-The following tool and service specific content was moved:
+The following tool- and service-specific content was moved:
 
 #### Jenkins Integration
 


### PR DESCRIPTION
- Demote "Separate Apple ID for CI"
- Separate additional headlines for application specific and spaceauth (so it is easier to link to it)
- Move limitations of spaceship session information

TODO: 
- [x] Better headlines that tell more about what is in there
- [x] Explain better what user should actually do
- [ ] Is this really the right place for this information? Or should the "how to log in to your Apple ID" stuff be somewhere else, and just the CI information should be here?