### PR TITLE
[codesigning/xcode-project] use `xcargs` instead of `export_xcargs`

### DIFF
--- a/docs/codesigning/xcode-project.md
+++ b/docs/codesigning/xcode-project.md
@@ -26,10 +26,10 @@ You can also use Xcode’s *Automatically Manage Signing* feature. By default, a
 
 ```ruby
 lane :beta do
-  build_app(xcargs: "-allowProvisioningUpdates")
+  build_app(export_xcargs: "-allowProvisioningUpdates")
 end
 ```
-
+Beware: For Xcode 10 you have to use `xcargs` instead of `export_xcargs`.
 
 # Xcode 8
 

--- a/docs/codesigning/xcode-project.md
+++ b/docs/codesigning/xcode-project.md
@@ -26,7 +26,7 @@ You can also use Xcode’s *Automatically Manage Signing* feature. By default, a
 
 ```ruby
 lane :beta do
-  build_app(export_xcargs: "-allowProvisioningUpdates")
+  build_app(xcargs: "-allowProvisioningUpdates")
 end
 ```
 


### PR DESCRIPTION
`export_xcargs` does not work for Xcode 10. `xcargs` should be used instead