### PR TITLE
Make app specific password requirements more clear

### DIFF
--- a/docs/best-practices/continuous-integration.md
+++ b/docs/best-practices/continuous-integration.md
@@ -60,7 +60,7 @@ If you want to upload builds to App Store Connect (actions `upload_to_app_store`
 
 This will supply the application specific password to iTMSTransporter, the tool used by those actions to perform the upload.
 
-It should be noted that the application specific password will only work for uploading the binary; it won't work for setting release notes or distributing to testers, etc.
+Note: The application specific password will _not_ work if your action usage does anything else than uploading the binary, e.g. updating any metadata like setting release notes or distributing to testers, etc.
 
 ##### `spaceauth`
 

--- a/docs/best-practices/continuous-integration.md
+++ b/docs/best-practices/continuous-integration.md
@@ -52,13 +52,15 @@ When you can not enter the security code manually, as on a Continuous Integratio
 
 ##### Application specific passwords
 
-If you want to upload builds to App Store Connect (actions `upload_to_app_store` and `deliver`) or TestFlight (actions `upload_to_testflight`, `pilot` or `testflight`, as long as you're only uploading a binary) from your CI machine, you need to generate an _application specific password_:
+If you want to upload builds to App Store Connect (actions `upload_to_app_store` and `deliver`) or TestFlight (actions `upload_to_testflight`, `pilot` or `testflight`) from your CI machine, you need to generate an _application specific password_:
 
 1. Visit [appleid.apple.com/account/manage](https://appleid.apple.com/account/manage)
 1. Generate a new application specific password
 1. Provide the application specific password using the environment variable `FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD`
 
 This will supply the application specific password to iTMSTransporter, the tool used by those actions to perform the upload.
+
+It should be noted that the application specific password will only work for uploading the binary; it won't work for setting release notes or distributing to testers, etc.
 
 ##### `spaceauth`
 

--- a/docs/best-practices/continuous-integration.md
+++ b/docs/best-practices/continuous-integration.md
@@ -52,7 +52,7 @@ When you can not enter the security code manually, as on a Continuous Integratio
 
 ##### Application specific passwords
 
-If you want to upload builds to App Store Connect (actions `upload_to_app_store` and `deliver`) or TestFlight (actions `upload_to testflight`, `pilot` or `testflight`) from your CI machine, you need to generate an _application specific password_:
+If you want to upload builds to App Store Connect (actions `upload_to_app_store` and `deliver`) or TestFlight (actions `upload_to_testflight`, `pilot` or `testflight`, as long as you're only uploading a binary) from your CI machine, you need to generate an _application specific password_:
 
 1. Visit [appleid.apple.com/account/manage](https://appleid.apple.com/account/manage)
 1. Generate a new application specific password


### PR DESCRIPTION
- Add more clarity about which cases allow the use of an application specific password, 
specifically in regards to TestFlight commands.
- Fix spelling mistake for command upload_to_testflight

This is a result of the conversation here https://github.com/fastlane/fastlane/issues/14365