### PR TITLE
Update reference to deprecated key

### DIFF
--- a/docs/getting-started/ios/beta-deployment.md
+++ b/docs/getting-started/ios/beta-deployment.md
@@ -199,7 +199,7 @@ Get a list of all available options using `fastlane action changelog_from_git_co
 ```ruby
 changelog_from_git_commits(
   between: ['7b092b3', 'HEAD'], # Optional, lets you specify a revision/tag range between which to collect commit info
-  include_merges: true # Optional, lets you filter out merge commits
+  merge_commit_filtering: exclude_merges # Optional, lets you filter out merge commits
 )
 ```
 ---


### PR DESCRIPTION
Update the `changelog_from_git_commits` call to use `merge_commit_filtering` instead of the deprecated `include_merges`.