### PR TITLE
circle ci: fix list

### DIFF
--- a/docs/best-practices/continuous-integration/circle-ci.md
+++ b/docs/best-practices/continuous-integration/circle-ci.md
@@ -76,10 +76,9 @@ jobs:
 ```
 
 This will do the following:
+
 * Create and use a Ruby gems cache.
 * Run the test lane on all pushes.
 * Collect Junit test results and store log output in the Artifacts tab.
 
-Check out [the CircleCI iOS
-doc](https://circleci.com/docs/2.0/testing-ios/#example-configuration-for-using-fastlane-on-circleci)
-for more detailed examples of using fastlane on CircleCI.
+Check out [the CircleCI iOS doc](https://circleci.com/docs/2.0/testing-ios/#example-configuration-for-using-fastlane-on-circleci) for more detailed examples of using fastlane on CircleCI.


### PR DESCRIPTION
https://docs.fastlane.tools/best-practices/continuous-integration/circle-ci/

list is currently broken, as required empty line is missing (works on Github, but not on the docs site)