### PR TITLE
Add instructions on how to test Google Play Store private key JSON file

### DIFF
--- a/docs/includes/google-credentials.md
+++ b/docs/includes/google-credentials.md
@@ -16,4 +16,4 @@ Tip: If you see Google Play Console or Google Developer Console in your local la
 1. Choose **Release Manager** (or alternatively **Project Lead**) from the `Role` dropdown. (Note that choosing **Release Manager** grants access to the production track and all other tracks. Choosing **Project Lead** grants access to update all tracks _except_ the production track.)
 1. Click **ADD USER** to close the dialog
 
-You can use `fastlane run validate_play_store_json_key json_key:/path/to/your/downloaded/file.json` to test the connection to Google Play Store with the downloaded private key.
+You can use [`fastlane run validate_play_store_json_key json_key:/path/to/your/downloaded/file.json`](https://docs.fastlane.tools/actions/validate_play_store_json_key/) to test the connection to Google Play Store with the downloaded private key.

--- a/docs/includes/google-credentials.md
+++ b/docs/includes/google-credentials.md
@@ -15,3 +15,5 @@ Tip: If you see Google Play Console or Google Developer Console in your local la
 1. Click on **Grant Access** for the newly added service account
 1. Choose **Release Manager** (or alternatively **Project Lead**) from the `Role` dropdown. (Note that choosing **Release Manager** grants access to the production track and all other tracks. Choosing **Project Lead** grants access to update all tracks _except_ the production track.)
 1. Click **ADD USER** to close the dialog
+
+You can use `fastlane run validate_play_store_json_key json_key:/path/to/your/downloaded/file.json` to test the connection to Google Play Store with the downloaded private key.


### PR DESCRIPTION
Now that https://docs.fastlane.tools/actions/validate_play_store_json_key/ is merged and usable, we can add this to the instructions.