### PR TITLE
Use config item valid logic

### DIFF
--- a/fastlane/actions/test_sample_code.rb
+++ b/fastlane/actions/test_sample_code.rb
@@ -65,11 +65,9 @@ module Fastlane
               next
             end
 
-            if config_item.data_type == Fastlane::Boolean
-              config_item.ensure_boolean_type_passes_validation(value)
-            else
-              config_item.ensure_generic_type_passes_validation(value)
-            end
+            # Setting verify_block to nil because not needed
+            config_item.verify_block = nil
+            config_item.valid?(value)
           end
         else
           UI.verbose("Legacy parameter technique for action '#{method_sym}'")


### PR DESCRIPTION
Because lets use the type logic that already exists in config item 😊