### PR TITLE
Fix display of markdown list

### DIFF
--- a/docs/getting-started/android/release-deployment.md
+++ b/docs/getting-started/android/release-deployment.md
@@ -44,6 +44,7 @@ end
 ```
 
 This will also:
+
 - Upload app metadata from `fastlane/metadata/android` if you previously ran `fastlane supply init`
 - Upload expansion files (obbs) found under the same directory as your APK as long as:
   - They are identified by type as **main** or **patch** by containing `main` or `patch` in their file names


### PR DESCRIPTION
The list must be in a new paragraph to be formatted as list and not as part of the previous paragraph.

This is how it is rendered without this patch, as you can see live in the docs: https://docs.fastlane.tools/getting-started/android/release-deployment/

![imagen](https://user-images.githubusercontent.com/307945/58167491-5384f980-7c8c-11e9-874e-09989d89e4fe.png)


<!--
Thanks for contributing to _fastlane_! Before you submit your pull request, note that files in the docs folder covering Actions (actions.md and actions/*) and Plugins (available-plugins.md) are auto-generated.
If this is the case, please modify the documentation at their sources (https://github.com/fastlane/fastlane or plugin repository) and will be updated here regularly.
-->
