### PR TITLE
fix misusage of `export_xcargs` option in xcode-project.md

### DIFF
--- a/docs/codesigning/xcode-project.md
+++ b/docs/codesigning/xcode-project.md
@@ -22,11 +22,11 @@ lane :beta do
 end
 ```
 
-You can also use Xcode’s *Automatically Manage Signing* feature. By default, automatic signing via `xcodebuild` is disabled. To enable it, pass `-allowProvisioningUpdates` via the `export_xcargs` option:
+You can also use Xcode’s *Automatically Manage Signing* feature. By default, automatic signing via `xcodebuild` is disabled. To enable it, pass `-allowProvisioningUpdates` via the `xcargs` option:
 
 ```ruby
 lane :beta do
-  build_app(export_xcargs: "-allowProvisioningUpdates")
+  build_app(xcargs: "-allowProvisioningUpdates")
 end
 ```
 


### PR DESCRIPTION
<!--
Thanks for contributing to _fastlane_! Before you submit your pull request, note that files in the docs folder covering Actions (actions.md and actions/*) and Plugins (available-plugins.md) are auto-generated.
If this is the case, please modify the documentation at their sources (https://github.com/fastlane/fastlane or plugin repository) and will be updated here regularly.
-->
