### PR TITLE
Adds a hint that "setup_travis" is not needed for Android

### DIFF
--- a/docs/best-practices/continuous-integration/travis.md
+++ b/docs/best-practices/continuous-integration/travis.md
@@ -22,3 +22,5 @@ setup_travis
 ```
 
 which will setup the keychain to work well with _match_ and _gym_. This action will also enable the `readonly` mode for _match_, so your CI doesn't create new certificates or provisioning profiles.
+
+Note: This is only required for iOS and not for Android.


### PR DESCRIPTION
It took me a while until I found out why my build was failing with exit code 127.

I interpreted the documentation like that: if I use fastlane with Travis CI I need to call the "setup_travis" action and was wondering why it's only showing an example for iOS.

To save someone the same trouble I added a note at the end of file.