### PR TITLE
Add note that FASTLANE_HIDE_TIMESTAMP is overruled by --verbose

### DIFF
--- a/docs/advanced/fastlane.md
+++ b/docs/advanced/fastlane.md
@@ -14,7 +14,7 @@ You can set the environment variable `FASTLANE_HIDE_CHANGELOG` to hide the detai
 
 ### Output environment variables
 
-- To hide timestamps in each row, set the `FASTLANE_HIDE_TIMESTAMP` environment variable to true.
+- To hide timestamps in each row, set the `FASTLANE_HIDE_TIMESTAMP` environment variable to true (overruled by `--verbose`). 
 - To disable output formatting, set the `FASTLANE_DISABLE_OUTPUT_FORMAT` environment variable to true.
 
 ## How fastlane works


### PR DESCRIPTION
See https://github.com/fastlane/fastlane/blob/f32b007ff45e648b37b6c9c2037ac481f36b7780/fastlane_core/lib/fastlane_core/ui/implementations/shell.rb#L33-L39

<!--
Thanks for contributing to _fastlane_! Before you submit your pull request, note that files in the docs folder covering Actions (actions.md and actions/*) and Plugins (available-plugins.md) are auto-generated.
If this is the case, please modify the documentation at their sources (https://github.com/fastlane/fastlane or plugin repository) and will be updated here regularly.
-->
