### PR TITLE
Fix typos across fastlane docs repository

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,7 +20,7 @@ Performance/RegexpMatch:
   Enabled: false
 
 # This suggests use of `tr` instead of `gsub`. While this might be more performant,
-# these methods are not at all interchangable, and behave very differently. This can
+# these methods are not at all interchangeable, and behave very differently. This can
 # lead to people making the substitution without considering the differences.
 Performance/StringReplacement:
   Enabled: false

--- a/docs/actions/appetize_viewing_url_generator.md
+++ b/docs/actions/appetize_viewing_url_generator.md
@@ -37,7 +37,7 @@ Key | Description | Default
   `color` | Color of the device | `black`
   `launch_url` | Specify a deep link to open when your app is launched | 
   `os_version` | The operating system version on which to run your app, e.g. 10.3, 8.0 | 
-  `params` | Specifiy params value to be passed to Appetize | 
+  `params` | Specify params value to be passed to Appetize | 
   `proxy` | Specify a HTTP proxy to be passed to Appetize | 
 
 <em id="parameters-legend-dynamic">* = default value is dependent on the user's system</em>

--- a/docs/actions/github_api.md
+++ b/docs/actions/github_api.md
@@ -67,7 +67,7 @@ Key | Description | Default
   `api_token` | Personal API Token for GitHub - generate one at https://github.com/settings/tokens | [*](#parameters-legend-dynamic)
   `http_method` | The HTTP method. e.g. GET / POST | `GET`
   `body` | The request body in JSON or hash format | `{}`
-  `raw_body` | The request body taken vertabim instead of as JSON, useful for file uploads | 
+  `raw_body` | The request body taken verbatim instead of as JSON, useful for file uploads | 
   `path` | The endpoint path. e.g. '/repos/:owner/:repo/readme' | 
   `url` | The complete full url - used instead of path. e.g. 'https://uploads.github.com/repos/fastlane...' | 
   `error_handlers` | Optional error handling hash based on status code, or pass '*' to handle all errors | `{}`

--- a/docs/actions/import_from_git.md
+++ b/docs/actions/import_from_git.md
@@ -52,7 +52,7 @@ Key | Description | Default
   `url` | The URL of the repository to import the Fastfile from | 
   `branch` | The branch or tag to check-out on the repository | `HEAD`
   `path` | The path of the Fastfile in the repository | `fastlane/Fastfile`
-  `version` | The version to checkout on the respository. Optimistic match operator or multiple conditions can be used to select the latest version within constraints | 
+  `version` | The version to checkout on the repository. Optimistic match operator or multiple conditions can be used to select the latest version within constraints | 
 
 <em id="parameters-legend-dynamic">* = default value is dependent on the user's system</em>
 

--- a/docs/plugins/available-plugins.md
+++ b/docs/plugins/available-plugins.md
@@ -2724,7 +2724,7 @@ tests | <b>30</b> | The more tests a plugin has, the better
 
 <p class="via-text">via Jiří Otáhal</p>
 
-> Automated version managment and generator of release notes.
+> Automated version management and generator of release notes.
 
 
 <details>
@@ -4404,7 +4404,7 @@ tests | <b>12</b> | The more tests a plugin has, the better
 
  Name | Category | Description
 ------|----------|------------
-  **instrumented_tests** | - | Run android instrumented tests via a gradle command againts a newly created avd
+  **instrumented_tests** | - | Run android instrumented tests via a gradle command against a newly created avd
 
 </details>
 
@@ -8853,7 +8853,7 @@ tests | <b>18</b> | The more tests a plugin has, the better
 ------|----------|------------
   **clean_build_cache_workspace** | - | Cleans workspace by removing old builds, using last access time for comparison
   **archive_derived_data** | - | Archives derived data folder in a zip file for later use
-  **check_build_cache_workspace** | - | Check if cache for current build is avaiable
+  **check_build_cache_workspace** | - | Check if cache for current build is available
   **unarchive_derived_data** | - | Unarchives derived data folder from a zip file
 
 </details>


### PR DESCRIPTION
:blue_heart: Fix typos across **fastlane docs** repository

### Fixed files :wrench: 

<details><summary>See all fixed files</summary>
<p>

```
docs/.rubocop.yml:23:31: "interchangable" is a misspelling of "interchangeable"
docs/docs/actions/appetize_viewing_url_generator.md:40:13: "Specifiy" is a misspelling of "Specify"
docs/docs/actions/github_api.md:70:38: "vertabim" is a misspelling of "verbatim"
docs/docs/actions/import_from_git.md:55:45: "respository" is a misspelling of "repository"
docs/docs/plugins/available-plugins.md:2727:20: "managment" is a misspelling of "management"
docs/docs/plugins/available-plugins.md:4407:83: "againts" is a misspelling of "against"
docs/docs/plugins/available-plugins.md:8856:76: "avaiable" is a misspelling of "available"
```

</p>
</details>

**FYI:** I used [**Go Spellchecker**](https://github.com/liamzdenek/go-spellcheck) :smile_cat: