### PR TITLE
Update gitlab.md

### DIFF
--- a/docs/best-practices/continuous-integration/gitlab.md
+++ b/docs/best-practices/continuous-integration/gitlab.md
@@ -67,8 +67,8 @@ To get an auto-incremented build number you can use something like the following
 
 ```ruby
 lane :increment_build_number do
-  increment_build_number(build_number: ENV['CI_BUILD_ID'])
+  increment_build_number(build_number: ENV['CI_JOB_ID'])
 end
 ```
 
-Then the GitLab CI build ID (which iterates on each build) will be used.
+Then the GitLab CI job ID (which iterates on each build) will be used.


### PR DESCRIPTION
Changed CI_BUILD_ID to the renamed CI_JOB_ID for auto-incremented build numbers, as described in the doc below 

https://docs.gitlab.com/ee/ci/variables/deprecated_variables.html#gitlab-90-renamed-variables

<!--
Thanks for contributing to _fastlane_! Before you submit your pull request, note that files in the docs folder covering Actions (actions.md and actions/*) and Plugins (available-plugins.md) are auto-generated.
If this is the case, please modify the documentation at their sources (https://github.com/fastlane/fastlane or plugin repository) and will be updated here regularly.
-->
