### PR TITLE
[cocoapods] Add clean_install option

### DIFF
--- a/docs/actions/cocoapods.md
+++ b/docs/actions/cocoapods.md
@@ -43,14 +43,15 @@ cocoapods(
 Key | Description | Default
 ----|-------------|--------
   `repo_update` | Add `--repo-update` flag to `pod install` command | `false`
+  `clean_install` | Execute a full pod installation ignoring the content of the project cache | `false`
   `silent` | Execute command without logging output | `false`
   `verbose` | Show more debugging information | `false`
   `ansi` | Show output with ANSI codes | `true`
   `use_bundle_exec` | Use bundle exec when there is a Gemfile presented | `true`
-  `podfile` | Explicitly specify the path to the Cocoapods' Podfile. You can either set it to the Podfile's path or to the folder containing the Podfile file | 
-  `error_callback` | A callback invoked with the command output if there is a non-zero exit status | 
+  `podfile` | Explicitly specify the path to the Cocoapods' Podfile. You can either set it to the Podfile's path or to the folder containing the Podfile file |
+  `error_callback` | A callback invoked with the command output if there is a non-zero exit status |
   `try_repo_update_on_error` | Retry with --repo-update if action was finished with error | `false`
-  `clean` | **DEPRECATED!** (Option removed from cocoapods) Remove SCM directories | `true`
+  `clean` | **DEPRECATED!** (Option renamed as clean_install) Remove SCM directories | `true`
   `integrate` | **DEPRECATED!** (Option removed from cocoapods) Integrate the Pods libraries into the Xcode project(s) | `true`
 
 <em id="parameters-legend-dynamic">* = default value is dependent on the user's system</em>


### PR DESCRIPTION
<!--
Thanks for contributing to _fastlane_! Before you submit your pull request, note that files in the docs folder covering Actions (actions.md and actions/*) and Plugins (available-plugins.md) are auto-generated.
If this is the case, please modify the documentation at their sources (https://github.com/fastlane/fastlane or plugin repository) and will be updated here regularly.
-->

### related PR

https://github.com/fastlane/fastlane/pull/15480

### overview

`--clean-install` option has been added to cocoapods since version 1.7.0.
I added cocoapods action to the option (related PR). So, I will also update docs.