### PR TITLE
Add no_checkout option to carthage action

### DIFF
--- a/docs/actions/carthage.md
+++ b/docs/actions/carthage.md
@@ -36,6 +36,7 @@ carthage(
   use_ssh: false,   # Use SSH for downloading GitHub repositories.
   use_submodules: false,      # Add dependencies as Git submodules.
   use_binaries: true,         # Check out dependency repositories even when prebuilt frameworks exist
+  no_checkout: false,         # When bootstrapping Carthage do not checkout
   no_build: false,  # When bootstrapping Carthage do not build
   no_skip_current: false,     # Don't skip building the current project (only for frameworks)
   verbose: false,   # Print xcodebuild output inline
@@ -61,6 +62,7 @@ Key | Description | Default
   `use_ssh` | Use SSH for downloading GitHub repositories | 
   `use_submodules` | Add dependencies as Git submodules | 
   `use_binaries` | Check out dependency repositories even when prebuilt frameworks exist | 
+  `no_checkout` | When bootstrapping Carthage do not checkout | 
   `no_build` | When bootstrapping Carthage do not build | 
   `no_skip_current` | Don't skip building the Carthage project (in addition to its dependencies) | 
   `derived_data` | Use derived data folder at path | 


### PR DESCRIPTION
<!--
Thanks for contributing to _fastlane_! Before you submit your pull request, note that files in the docs folder covering Actions (actions.md and actions/*) and Plugins (available-plugins.md) are auto-generated.
If this is the case, please modify the documentation at their sources (https://github.com/fastlane/fastlane or plugin repository) and will be updated here regularly.
-->

### related PR

https://github.com/fastlane/fastlane/pull/15482

### overview

Latest (ver: 0.33.0) carthage boot strap command has `--no-checkout` option.
But carthage action isn't implemented the option.
So, I made PR to add the option. I'll also update docs.