### PR TITLE
Plugins - add more clarity for using `bundle exec` after installing plugins

### DIFF
--- a/docs/plugins/using-plugins.md
+++ b/docs/plugins/using-plugins.md
@@ -75,6 +75,12 @@ gem "fastlane-plugin-xcversion", ">= 1.0"
 
 [More information about a Gemfile](http://bundler.io/gemfile.html)
 
+### Run with plugins
+
+Run _fastlane_ using `bundle exec fastlane [lane]` to make sure your plugins are properly loaded.
+
+This is required when you use plugins from a local path or a git remote.
+
 ## Install plugins on another machine
 
 To make sure all plugins are installed on the local machine, run

--- a/docs/plugins/using-plugins.md
+++ b/docs/plugins/using-plugins.md
@@ -79,7 +79,7 @@ gem "fastlane-plugin-xcversion", ">= 1.0"
 
 Run _fastlane_ using `bundle exec fastlane [lane]` to make sure your plugins are properly loaded.
 
-This is required when you use plugins from a local path or a git remote.
+This is required when you use plugins from a local path or a git remote. If you have multiple versions of the same plugin loaded, you may not be using the one you specified in your `Gemfile`.
 
 ## Install plugins on another machine
 

--- a/docs/plugins/using-plugins.md
+++ b/docs/plugins/using-plugins.md
@@ -79,7 +79,7 @@ gem "fastlane-plugin-xcversion", ">= 1.0"
 
 Run _fastlane_ using `bundle exec fastlane [lane]` to make sure your plugins are properly loaded.
 
-This is required when you use plugins from a local path or a git remote. If you have multiple versions of the same plugin loaded, you may not be using the one you specified in your `Gemfile`.
+This is required when you use plugins from a local path or a git remote. If you have multiple versions of the same plugin loaded, you may not be using the one you specified in your `Pluginfile` or `Gemfile`.
 
 ## Install plugins on another machine
 


### PR DESCRIPTION
Helps fix https://github.com/fastlane/fastlane/issues/15506
Helps fix https://github.com/fastlane/fastlane/issues/15506[

Not clear to users will now have to use `bundle exec` after installing plugins 😊 