### PR TITLE
Add Semaphore CI to the continuous integration documentation page

### DIFF
--- a/docs/best-practices/continuous-integration.md
+++ b/docs/best-practices/continuous-integration.md
@@ -20,6 +20,7 @@ Multiple CI products and services offer integrations with fastlane:
 - [GitLab CI](/best-practices/continuous-integration/gitlab/)
 - [Azure DevOps](/best-practices/continuous-integration/azure-devops/) (formerly known as: Visual Studio Team Services)
 - [NeverCode](/best-practices/continuous-integration/nevercode/)
+- [Semaphore](/best-practices/continuous-integration/semaphore/)
 
 ## Authentication with Apple services
 
@@ -27,7 +28,7 @@ Several Fastlane actions communicate with Apple services that need authenticatio
 
 ### Separate Apple ID for CI
 
-The easiest way to get _fastlane_ running on a CI system is to create a separate Apple ID that 
+The easiest way to get _fastlane_ running on a CI system is to create a separate Apple ID that
 
   - doesn't have 2-factor authentication enabled
   - doesn't have the Account Holder role
@@ -42,7 +43,7 @@ Note: [Apple announced that as of February 27th 2019](https://developer.apple.co
 
 #### Security code and session
 
-When your Apple account has 2-factor authentication (or 2-step verification) enabled, you will be asked to verify your identity by entering a security code. If you already have a trusted device configured for your account, then the code will appear on the device. If you don't have any devices configured, but have trusted a phone number, then the code will be sent to your phone. 
+When your Apple account has 2-factor authentication (or 2-step verification) enabled, you will be asked to verify your identity by entering a security code. If you already have a trusted device configured for your account, then the code will appear on the device. If you don't have any devices configured, but have trusted a phone number, then the code will be sent to your phone.
 
 The resulting session will be stored in `~/.fastlane/spaceship/[email]/cookie`, which should be valid for about one month.
 
@@ -119,7 +120,7 @@ You can set up your own ```Release``` job, which is only triggered manually.
     var hash = window.location.hash.substring(1);
     if (hash) {
         /*
-        * Best practice for javascript redirects: 
+        * Best practice for javascript redirects:
         * https://stackoverflow.com/a/506004/151365
         */
         if (anchorMap[hash]) {

--- a/docs/best-practices/continuous-integration/semaphore.md
+++ b/docs/best-practices/continuous-integration/semaphore.md
@@ -1,0 +1,123 @@
+# Semaphore CI Integration
+
+[Semaphore](https://semaphoreci.com) provides simple, fast continuous integration and delivery for your iOS apps. All [macOS machine images](https://docs.semaphoreci.com/article/162-macos-mojave-xcode-11-image) have fastlane tools pre-installed and getting up and running is quick and simple.
+
+## Add the Semaphore fastlane plugin
+
+The [Semaphore fastlane plugin](https://github.com/semaphoreci/fastlane-plugin-semaphore) creates a temporary keychain, sets `match` to read-only mode and (optionally) redirects log output from `scan` and `gym`.
+
+Install the plugin from your app's project directory:
+
+``` bash
+fastlane add_plugin semaphore
+```
+
+Then, from your `Fastfile`:
+
+``` ruby
+before_all do
+  setup_semaphore
+end
+```
+
+## Configure a pipeline on Semaphore
+
+Configure continuous integration pipelines on Semaphore with a `.semaphore/semaphore.yml` file in your app's source repository. Then, add the repository to your [Semaphore dashboard](https://me.semaphoreci.com) and your continuous integration will start.
+
+For full details of how pipelines work on Semaphore see the [documentation](https://docs.semaphoreci.com/article/124-ios-continuous-integration-xcode), or the [example project](https://github.com/semaphoreci-demos/semaphore-demo-ios-swift-xcode).
+
+## Example Pipeline
+
+``` yaml
+# Use the latest stable version of Semaphore 2.0 YML syntax:
+version: v1.0
+
+# Name your pipeline. If you choose to connect multiple pipelines with
+# promotions, the pipeline name will help you differentiate between
+# them. For example, you might have a build phase and a delivery phase.
+# For more information on promotions, see:
+# https://docs.semaphoreci.com/article/67-deploying-with-promotions
+name: Tallest Towers
+
+# The agent defines the environment in which your CI runs. It is a combination
+# of a machine type and an operating system image. For a project built with
+# Xcode you must use one of the Apple machine types, coupled with a macOS image
+# running either Xcode 10 or Xcode 11.
+# See https://docs.semaphoreci.com/article/20-machine-types
+# https://docs.semaphoreci.com/article/161-macos-mojave-xcode-10-image and
+# https://docs.semaphoreci.com/article/162-macos-mojave-xcode-11-image
+agent:
+  machine:
+    type: a1-standard-4
+    os_image: macos-mojave-xcode11
+
+# Blocks are the heart of a pipeline and are executed sequentially. Each block
+# has a task that defines one or more parallel jobs. Jobs define commands that
+# should be executed by the pipeline.
+# See https://docs.semaphoreci.com/article/62-concepts
+blocks:
+  - name: Run tests
+    task:
+      # Set environment variables that your project requires.
+      # See https://docs.semaphoreci.com/article/66-environment-variables-and-secrets
+      env_vars:
+        - name: LANG
+          value: en_US.UTF-8
+      prologue:
+        commands:
+          # Download source code from GitHub.
+          - checkout
+
+          # Restore dependencies from cache. This command will not fail in
+          # case of a cache miss. In case of a cache hit, bundle  install will
+          # complete in about a second.
+          # See https://docs.semaphoreci.com/article/68-caching-dependencies
+          - cache restore
+          - bundle install --path vendor/bundle
+          - cache store
+      jobs:
+        - name: Test
+          commands:
+            # Select an Xcode version.
+            # See https://docs.semaphoreci.com/article/161-macos-mojave-xcode-10-image and
+            # https://docs.semaphoreci.com/article/162-macos-mojave-xcode-11-image
+            - bundle exec xcversion select 11.2.1
+
+            # Run tests of iOS and Mac app on a simulator or connected device.
+            # See https://docs.fastlane.tools/actions/scan/
+            - bundle exec fastlane test
+
+  - name: Build app
+    task:
+      env_vars:
+        - name: LANG
+          value: en_US.UTF-8
+      prologue:
+        commands:
+          - checkout
+          - cache restore
+          - bundle install --path vendor/bundle
+          - cache store
+      jobs:
+        - name: Build
+          commands:
+            - bundle exec xcversion select 11.2.1
+            - bundle exec fastlane build
+  - name: Take screenshots
+    task:
+      env_vars:
+        - name: LANG
+          value: en_US.UTF-8
+      prologue:
+        commands:
+          - checkout
+          - cache restore
+          - bundle install --path vendor/bundle
+          - cache store
+      jobs:
+        - name: Screenshots
+          commands:
+            - bundle exec xcversion select 11.2.1
+            - bundle exec fastlane screenshots
+            - artifact push project screenshots
+```

--- a/docs/best-practices/continuous-integration/semaphore.md
+++ b/docs/best-practices/continuous-integration/semaphore.md
@@ -1,6 +1,6 @@
 # Semaphore CI Integration
 
-[Semaphore](https://semaphoreci.com) provides simple, fast continuous integration and delivery for your iOS apps. All [macOS machine images](https://docs.semaphoreci.com/article/162-macos-mojave-xcode-11-image) have fastlane tools pre-installed and getting up and running is quick and simple.
+[Semaphore](https://semaphoreci.com) provides simple, fast continuous integration and delivery for your iOS apps. All [macOS machine images](https://docs.semaphoreci.com/article/162-macos-mojave-xcode-11-image) have _fastlane_ pre-installed and getting up and running is quick and simple.
 
 ## Add the Semaphore fastlane plugin
 


### PR DESCRIPTION
Hello! I've been doing some work with [Semaphore](https://semaphoreci.com) recently and noticed that they are not listed on the continuous integration page so I popped together some documentation and here it is!

Thanks!
Dave