### PR TITLE
Update CircleCI to use fastlane docker 0.2.0 with Ruby 2.4.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.0
 jobs:
   "Test":
     docker:
-      - image: fastlanetools/ci:0.1.0
+      - image: fastlanetools/ci:0.2.0
     working_directory: ~/code
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       - run: bundle exec danger || echo "danger failed, moving on"
   "Deploy":
     docker:
-      - image: fastlanetools/ci:0.1.0
+      - image: fastlanetools/ci:0.2.0
     working_directory: ~/code
     steps:
       - checkout


### PR DESCRIPTION
Fixes issue with deploy not working because of previous running Ruby < 2.4 which caused weird errors
