### PR TITLE
Install Bundler on Deploy as well

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,8 @@ jobs:
       - checkout
       - run: sudo pip3 install pipenv
       - run: pipenv install
+      - run: gem install bundler
+      - run: bundle update
       - run: pipenv run ./scripts/ci/deploy.sh
 
 workflows:


### PR DESCRIPTION
Currently deploys are failing because it seems to have old bundler that doesn't match the lock file: https://circleci.com/gh/fastlane/docs/2244

```
To github.com:fastlane/docs.git
   685bb9c5..2146a5b5  gh-pages -> gh-pages
Switched to branch 'master'
Your branch is up-to-date with 'origin/master'.
You must use Bundler 2 or greater with this lockfile.
```