### PR TITLE
Update brew installation with non-cask

### DIFF
--- a/docs/includes/installing-fastlane.md
+++ b/docs/includes/installing-fastlane.md
@@ -11,5 +11,5 @@ Install _fastlane_ using
 sudo gem install fastlane -NV
 
 # Alternatively using Homebrew
-brew cask install fastlane
+brew install fastlane
 ```


### PR DESCRIPTION
Brew cask formula installs pretty old version (2.28.3) and according to this issue: https://github.com/fastlane/fastlane/issues/15496 theres also `brew install fastlane` which seems to install latest version.

<!--
Thanks for contributing to _fastlane_! Before you submit your pull request, note that files in the docs folder covering Actions (actions.md and actions/*) and Plugins (available-plugins.md) are auto-generated.
If this is the case, please modify the documentation at their sources (https://github.com/fastlane/fastlane or plugin repository) and will be updated here regularly.
-->
