### PR TITLE
Updated brew installation instructions

### DIFF
--- a/docs/includes/installing-fastlane.md
+++ b/docs/includes/installing-fastlane.md
@@ -11,5 +11,5 @@ Install _fastlane_ using
 sudo gem install fastlane -NV
 
 # Alternatively using Homebrew
-brew cask install fastlane
+brew install fastlane
 ```


### PR DESCRIPTION
According to [this note](https://github.com/fastlane/fastlane/issues/15496#issuecomment-565028879) by @joshdholtz, the old method of using `brew cask install fastlane` doesn't work anymore, as it installs an old version. The currently supported way is `brew install fastlane` (sans `cask`), which is not reflected in the docs just yet.