### PR TITLE
best practices ci: Update Xcode version

### DIFF
--- a/docs/best-practices/continuous-integration/circle-ci.md
+++ b/docs/best-practices/continuous-integration/circle-ci.md
@@ -51,7 +51,7 @@ version: 2
 jobs:
   build:
     macos:
-      xcode: "9.0"
+      xcode: "11.3"
     working_directory: /Users/distiller/project
     environment:
       FL_OUTPUT_DIR: output


### PR DESCRIPTION
Xcode 9 is very old now and will likely be deprecated in the not too distant future, so updating the example here to 11.3