### PR TITLE
Update remaining brew install commands away from cask

### DIFF
--- a/docs/includes/setup-fastlane-header.md
+++ b/docs/includes/setup-fastlane-header.md
@@ -40,7 +40,7 @@ xcode-select --install
 sudo gem install fastlane -NV
 
 # Alternatively using Homebrew
-brew cask install fastlane
+brew install fastlane
 ```
 
 <p class="fastlane-setup-header">3) Navigate to your project and run</p>

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -12,7 +12,7 @@ Install _fastlane_ using
 ```
 [sudo] gem install fastlane -NV
 ```
-or alternatively using `brew cask install fastlane`
+or alternatively using `brew install fastlane`
 
 # Available Actions
 ### test


### PR DESCRIPTION
Following up on https://github.com/fastlane/docs/pull/895 which missed a couple of other references to `brew cask install fastlane`.

The context of the [original issue](https://github.com/fastlane/fastlane/issues/15496#issuecomment-565028879) is that installing via `cask` leads to installation of an old version (2.28.3) of fastlane.

PS thanks for maintaining this tool!