### PR TITLE
Update octokit (4.17.0) was yanked

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,7 +159,7 @@ GEM
     nap (1.1.0)
     naturally (2.2.0)
     no_proxy_fix (0.1.2)
-    octokit (4.17.0)
+    octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     open4 (1.3.4)


### PR DESCRIPTION
gem was yanked so CI is failing over on https://github.com/fastlane/fastlane/pull/16217