### PR TITLE
Improve device names in screenshots documentation

### DIFF
--- a/docs/getting-started/ios/screenshots.md
+++ b/docs/getting-started/ios/screenshots.md
@@ -101,12 +101,16 @@ The setup process will also generate a `Snapfile`, looking similar to
 ```ruby
 # A list of devices you want to take the screenshots from
 # devices([
-#   "iPhone 6",
-#   "iPhone 6 Plus",
-#   "iPhone 5",
-#   "iPhone 4s",
-#   "iPad Retina",
-#   "iPad Pro"
+#  "iPad (7th generation)",
+#  "iPad Air (3rd generation)",
+#  "iPad Pro (11-inch)",
+#  "iPad Pro (12.9-inch) (3rd generation)",
+#  "iPad Pro (9.7-inch)",
+#  "iPhone 11",
+#  "iPhone 11 Pro",
+#  "iPhone 11 Pro Max",
+#  "iPhone 8",
+#  "iPhone 8 Plus"
 # ])
 
 languages([


### PR DESCRIPTION
Fixes #845

This is the full list I got when running 

> instruments -s devices

on a mac with Xcode 11.3.1, 10.2.1, 11.1, 11

```Apple TV (13.3) 
Apple TV 4K (13.3) 
Apple TV 4K (at 1080p) (13.3) 
Apple Watch Series 4 - 40mm (6.1.1) 
Apple Watch Series 4 - 44mm (6.1.1) 
iPad (5th generation) (10.3.1) 
iPad (5th generation) (11.4) 
iPad (6th generation) (11.4) 
iPad (7th generation) (13.3) 
iPad Air (10.3.1) 
iPad Air (11.4) 
iPad Air (3rd generation) (13.3) 
iPad Air 2 (10.3.1) 
iPad Air 2 (11.4) 
iPad Pro (10.5-inch) (10.3.1) 
iPad Pro (10.5-inch) (11.4) 
iPad Pro (11-inch) (13.3) 
iPad Pro (12.9 inch) (10.3.1) 
iPad Pro (12.9-inch) (11.4) 
iPad Pro (12.9-inch) (2nd generation) (10.3.1) 
iPad Pro (12.9-inch) (2nd generation) (11.4) 
iPad Pro (12.9-inch) (3rd generation) (13.3) 
iPad Pro (9.7 inch) (10.3.1) 
iPad Pro (9.7-inch) (11.4) 
iPad Pro (9.7-inch) (13.3) 
iPhone 11 (13.3) 
iPhone 11 Pro (13.3) 
iPhone 11 Pro (13.3) + Apple Watch Series 5 - 40mm (6.1.1) 
iPhone 11 Pro Max (13.3) 
iPhone 11 Pro Max (13.3) + Apple Watch Series 5 - 44mm (6.1.1) 
iPhone 5 (10.3.1) 
iPhone 5s (10.3.1) 
iPhone 5s (11.4) 
iPhone 6 (10.3.1) 
iPhone 6 (11.4) 
iPhone 6 Plus (10.3.1) 
iPhone 6 Plus (11.4) 
iPhone 6s (10.3.1) 
iPhone 6s (11.4) 
iPhone 6s Plus (10.3.1) 
iPhone 6s Plus (11.4) 
iPhone 7 (10.3.1) 
iPhone 7 (11.4) 
iPhone 7 Plus (10.3.1) 
iPhone 7 Plus (11.4) 
iPhone 8 (11.4) 
iPhone 8 (13.3) 
iPhone 8 Plus (11.4) 
iPhone 8 Plus (13.3) 
iPhone SE (10.3.1) 
iPhone SE (11.4) 
iPhone X (11.4)```