### PR TITLE
add keychain troubleshoot explanation when `login.keychain` is not the default keychain

### DIFF
--- a/docs/codesigning/troubleshooting.md
+++ b/docs/codesigning/troubleshooting.md
@@ -49,7 +49,7 @@ If a certificate gets revoked, all connected provisioning profiles get invalidat
   <img src="/img/codesigning/KeychainPrivateKey.png" width=500 />
 </p>
 1. Make sure to have deleted all expired WWDR certificates, more information [here](https://stackoverflow.com/questions/32821189/xcode-7-error-missing-ios-distribution-signing-identity-for/35401483#35401483). There might be 2 expired WWDR certificates, one in the `login`, and one in the `system` keychain
-1. Run `security default-keychain` to view the default keychain that is used by some fastlane actions if a keychain path is not explicitly provided.  If it's the system keychain, make sure fastlane has access to write to it.  You may want to reconfigure your enviroment so the default keychain is the login keychain, which is less prone to permissions errors.  If you're using launchctl, see [this link to change the default keychain to the login keychain](https://serverfault.com/a/371252).
+1. Run `security default-keychain` to view the default keychain that is used by some _fastlane_ actions if a keychain path is not explicitly provided.  If it's the system keychain, make sure _fastlane_ has access to write to it.  You may want to reconfigure your enviroment so the default keychain is the login keychain, which is less prone to permissions errors.  If you're using `launchctl`, see [this link to change the default keychain to the login keychain](https://serverfault.com/a/371252).
 
 ## Have you tried turning it off and on again?
 

--- a/docs/codesigning/troubleshooting.md
+++ b/docs/codesigning/troubleshooting.md
@@ -49,6 +49,7 @@ If a certificate gets revoked, all connected provisioning profiles get invalidat
   <img src="/img/codesigning/KeychainPrivateKey.png" width=500 />
 </p>
 1. Make sure to have deleted all expired WWDR certificates, more information [here](https://stackoverflow.com/questions/32821189/xcode-7-error-missing-ios-distribution-signing-identity-for/35401483#35401483). There might be 2 expired WWDR certificates, one in the `login`, and one in the `system` keychain
+1. Run `security default-keychain` to view the default keychain that is used by some fastlane actions if a keychain path is not explicitly provided.  If it's the system keychain, make sure fastlane has access to write to it.  You may want to reconfigure your enviroment so the default keychain is the login keychain, which is less prone to permissions errors.  If you're using launchctl, see [this link to change the default keychain to the login keychain](https://serverfault.com/a/371252).
 
 ## Have you tried turning it off and on again?
 


### PR DESCRIPTION
I was running into an issue using GitHub actions where fastlane was using the system keychain instead of the login keychain.  It didn't have access to the system keychain so some commands would fail.

<!--
Thanks for contributing to _fastlane_! Before you submit your pull request, note that files in the docs folder covering Actions (actions.md and actions/*) and Plugins (available-plugins.md) are auto-generated.
If this is the case, please modify the documentation at their sources (https://github.com/fastlane/fastlane or plugin repository) and will be updated here regularly.
-->
