### PR TITLE
Update Swift Docs to describe plugin support

### DIFF
--- a/docs/getting-started/ios/fastlane-swift.md
+++ b/docs/getting-started/ios/fastlane-swift.md
@@ -6,10 +6,7 @@ Fastlane.swift is currently in beta. Please provide feedback by opening an issue
 
 ## Currently Supported
 
-Fastlane.swift currently supports all built-in [fastlane actions](https://docs.fastlane.tools/actions/). Make sure to update to the most recent _fastlane_ release to try this feature.
-
-## PLugins 
-When you add any plugin fastlane the corresponding API will be automatically available in `fastlane/swift/Plugins.swift`
+Fastlane.swift currently supports all built-in [fastlane actions](https://docs.fastlane.tools/actions/) and 3rd party [plugins](https://docs.fastlane.tools/plugins/available-plugins/). Make sure to update to the most recent _fastlane_ release to try this feature.
 
 ## Get Started
 
@@ -86,6 +83,18 @@ class Fastfile: LaneFile {
     }
 }
 ```
+
+## Using Plugins
+
+Once you [add a plugin](https://docs.fastlane.tools/plugins/using-plugins/#add-a-plugin-to-your-project), _fastlane_ will automatically generate the corresponding API and make it available in `fastlane/swift/Plugins.swift`.
+
+Example:
+
+```sh
+bundle exec fastlane add_plugin ascii_art
+```
+
+The `fastlane/swift/Plugins.swift` file should now contain the function `asciiArt()`, and you can access it in your lanes in `fastlane/Fastlane.swift`.
 
 ## Run Parallel
 

--- a/docs/getting-started/ios/fastlane-swift.md
+++ b/docs/getting-started/ios/fastlane-swift.md
@@ -8,6 +8,9 @@ Fastlane.swift is currently in beta. Please provide feedback by opening an issue
 
 Fastlane.swift currently supports all built-in [fastlane actions](https://docs.fastlane.tools/actions/). Make sure to update to the most recent _fastlane_ release to try this feature.
 
+## PLugins 
+When you add any plugin fastlane the corresponding API will be automatically available in `fastlane/swift/Plugins.swift`
+
 ## Get Started
 
 ### Step 1
@@ -93,10 +96,6 @@ To specify `socket port` from the command line to your lane, use the fllowing sy
 ```no-highlight
 fastlane [lane] --swift_server_port [socket port]
 ```
-
-## Known Limitations
-
-Currently, Fastlane.swift does not have support for plugins. This is a work in progress and we will continue to update this doc with the current working condition of each feature as we move from beta to general availability.
 
 ## We Would Love Your Feedback
 

--- a/docs/getting-started/ios/fastlane-swift.md
+++ b/docs/getting-started/ios/fastlane-swift.md
@@ -6,7 +6,7 @@ Fastlane.swift is currently in beta. Please provide feedback by opening an issue
 
 ## Currently Supported
 
-Fastlane.swift currently supports all built-in [fastlane actions](https://docs.fastlane.tools/actions/) and 3rd party [plugins](https://docs.fastlane.tools/plugins/available-plugins/). Make sure to update to the most recent _fastlane_ release to try this feature.
+Fastlane.swift currently supports all built-in [fastlane actions](https://docs.fastlane.tools/actions/) and 3rd party [plugins](https://docs.fastlane.tools/plugins/available-plugins/). Make sure to update to the most recent _fastlane_ release to try these features.
 
 ## Get Started
 


### PR DESCRIPTION
After the reading the currently available documentation it appeared as if there was no plugin support for Fastlane Swift. I was luckily to stumble upon this PR, and find out that it actually was supported. 

https://github.com/fastlane/fastlane/pull/15203

I've updated the docs to reflect this


