### PR TITLE
Make clarity in OS supported and setting up different platforms

### DIFF
--- a/docs/getting-started/ios/setup.md
+++ b/docs/getting-started/ios/setup.md
@@ -1,5 +1,9 @@
 # Getting started with _fastlane_ for iOS
 
+## Setup Xcode for _fastlane_
+
+{!docs/includes/installing-fastlane-ios.md!}
+
 ## Installing _fastlane_
 
 {!docs/includes/installing-fastlane.md!}

--- a/docs/includes/installing-fastlane-ios.md
+++ b/docs/includes/installing-fastlane-ios.md
@@ -1,0 +1,5 @@
+### Xcode command line tools (macOS)
+
+```no-highlight
+xcode-select --install
+```

--- a/docs/includes/installing-fastlane.md
+++ b/docs/includes/installing-fastlane.md
@@ -1,15 +1,28 @@
-Install the latest Xcode command line tools:
+_fastlane_ can be installed in a multiple ways. The preferred method is with a `Gemfile`. _fastlane_ can also get installed directly through RubyGems or with Homebrew (if on macOS).
 
-```no-highlight
-xcode-select --install
+#### A Gemfile (macOS/Linux/Windows)
+
+It is recommended that you use a `Gemfile` to define your dependency on _fastlane_. This will clearly define the used _fastlane_ version, and its dependencies, and will also speed up using _fastlane_.
+
+- Create a `./Gemfile` in the root directory of your project with the content
+```ruby
+source "https://rubygems.org"
+
+gem "fastlane"
 ```
+- Run `[sudo] bundle update` and add both the `./Gemfile` and the `./Gemfile.lock` to version control
+- Every time you run _fastlane_, use `bundle exec fastlane [lane]`
+- On your CI, add `[sudo] bundle install` as your first build step
+- To update _fastlane_, just run `[sudo] bundle update fastlane`
 
-Install _fastlane_ using
+#### RubyGems (macOS/Linux/Windows)
 
 ```sh
-# Using RubyGems
 sudo gem install fastlane -NV
+```
 
-# Alternatively using Homebrew
+#### Homebrew (macOS)
+
+```sh
 brew install fastlane
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,7 @@ fastlane
 [![Twitter: @FastlaneTools](https://img.shields.io/badge/contact-@FastlaneTools-blue.svg?style=flat)](https://twitter.com/FastlaneTools){: .badge }
 [![License](https://img.shields.io/badge/license-MIT-green.svg?style=flat)](https://github.com/fastlane/fastlane/blob/master/LICENSE){: .badge }
 [![Gem](https://img.shields.io/gem/v/fastlane.svg?style=flat)](https://rubygems.org/gems/fastlane){: .badge }
+![Platforms](https://img.shields.io/badge/os-macos%20--%20linux%20--%20windows-blue)
 
 _fastlane_ is the easiest way to automate beta deployments and releases for your iOS and Android apps. 🚀 It handles all tedious tasks, like generating screenshots, dealing with code signing, and releasing your application.
 
@@ -49,7 +50,11 @@ fastlane release
 
 ## Getting Started
 
+### Installing _fastlane_
+
 {!docs/includes/installing-fastlane.md!}
+
+### Setting up _fastlane_
 
 Navigate to your iOS or Android app and run
 


### PR DESCRIPTION
- Show label for OSes supported on main index page
- Don’t show Xcode setup process for Android
- Add Gemfile as preferred setup method

## Screenshots

### Main
![970496C3-9743-4CB6-B699-87B7DB778201](https://user-images.githubusercontent.com/401294/88420015-cb2c4800-cdab-11ea-8275-bacb813b537f.jpeg)

### iOS
![DA6FD1D6-4D91-412F-B966-11C35CC334F9](https://user-images.githubusercontent.com/401294/88420016-cbc4de80-cdab-11ea-8f5b-7928320a2159.jpeg)

### Android
![E9488541-D2F4-409C-8946-5AA04DBB62C0](https://user-images.githubusercontent.com/401294/88420017-ccf60b80-cdab-11ea-8637-bee8584e0207.jpeg)




