### PR TITLE
Updated Docs to Reflect Support for Swift Plugins

### DIFF
--- a/docs/getting-started/ios/fastlane-swift.md
+++ b/docs/getting-started/ios/fastlane-swift.md
@@ -84,6 +84,15 @@ class Fastfile: LaneFile {
 }
 ```
 
+## Using Plugins
+
+Search for a plugin you'd like to use: https://docs.fastlane.tools/plugins/available-plugins/
+
+If the plugin is ascii_art, for example, type the following into your terminal: `bundle exec fastlane add_plugin ascii_art`. The `fastlane/swift/Plugins.swift` file should now contain the function `asciiArt()`
+
+You're now free to use any plugin functions in your `fastlane/Fastlane.swift` lanes.
+
+
 ## Run Parallel
 
 `Fastlane Swift` uses socket internally. Therefore, for several `Lane`s to run in parallel at the same time, each `Lane` must be specified different `socket port` (lane's default `socket port` is `2000`)

--- a/docs/getting-started/ios/fastlane-swift.md
+++ b/docs/getting-started/ios/fastlane-swift.md
@@ -6,7 +6,7 @@ Fastlane.swift is currently in beta. Please provide feedback by opening an issue
 
 ## Currently Supported
 
-Fastlane.swift currently supports all built-in [fastlane actions](https://docs.fastlane.tools/actions/). Make sure to update to the most recent _fastlane_ release to try this feature.
+Fastlane.swift currently supports all built-in [fastlane actions](https://docs.fastlane.tools/actions/) and 3rd party [plugins](https://docs.fastlane.tools/plugins/available-plugins/). Make sure to update to the most recent _fastlane_ release to try this feature.
 
 ## Get Started
 
@@ -93,10 +93,6 @@ To specify `socket port` from the command line to your lane, use the following s
 ```no-highlight
 fastlane [lane] --swift_server_port [socket port]
 ```
-
-## Known Limitations
-
-Currently, Fastlane.swift does not have support for plugins. This is a work in progress and we will continue to update this doc with the current working condition of each feature as we move from beta to general availability.
 
 ## We Would Love Your Feedback
 


### PR DESCRIPTION
Plugins have been supported in Fastlane Swift since this PR: https://github.com/fastlane/fastlane/pull/15203 was merged and went out in https://github.com/fastlane/fastlane/releases/tag/2.130.0

<!--
Thanks for contributing to _fastlane_! Before you submit your pull request, note that files in the docs folder covering Actions (actions.md and actions/*) and Plugins (available-plugins.md) are auto-generated.
If this is the case, please modify the documentation at their sources (https://github.com/fastlane/fastlane or plugin repository) and will be updated here regularly.
-->
