### PR TITLE
Add note about requiring apple_id when using pilot with app specific password

### DIFF
--- a/docs/best-practices/continuous-integration.md
+++ b/docs/best-practices/continuous-integration.md
@@ -62,7 +62,7 @@ If you want to upload builds to App Store Connect (actions `upload_to_app_store`
 
 This will supply the application specific password to iTMSTransporter, the tool used by those actions to perform the upload.
 
-Note: The application specific password will _not_ work if your action usage does anything else than uploading the binary, e.g. updating any metadata like setting release notes or distributing to testers, etc.
+Note: The application specific password will _not_ work if your action usage does anything else than uploading the binary, e.g. updating any metadata like setting release notes or distributing to testers, etc. Additionally, when using `pilot`/`upload_to_testflight`, you _must explicitly provide a value for `apple_id`_, otherwise the action requires an auth session and will not use the application specific password.
 
 ##### `spaceauth`
 


### PR DESCRIPTION
The pilot action requires an explicitly provided value for `apple_id` when using the application specific password auth strategy, otherwise it attempts to create an auth session with App Store Connect. Presumably to look up the value for `apple_id`.

This would have saved me hours of debugging trying to get the app specific password to work, and I would like to spare others from that going forward. The clue I needed was in this comment https://github.com/fastlane/fastlane/issues/17062#issuecomment-676612397.

<!--
Thanks for contributing to _fastlane_! Before you submit your pull request, note that files in the docs folder covering Actions (actions.md and actions/*) and Plugins (available-plugins.md) are auto-generated.
If this is the case, please modify the documentation at their sources (https://github.com/fastlane/fastlane or plugin repository) and will be updated here regularly.
-->
