### PR TITLE
Replace Crashlytics beta deployment with Firebase App Distribution

### DIFF
--- a/docs/getting-started/android/beta-deployment.md
+++ b/docs/getting-started/android/beta-deployment.md
@@ -75,7 +75,21 @@ fastlane action upload_to_play_store
 </details>
 
 <details>
-<summary>Crashlytics</summary>
+<summary>Firebase App Distribution</summary>
+
+Install the Firebase App Distribution plugin:
+
+```no-highlight
+fastlane add_plugin firebase_app_distribution
+```
+
+Authenticate with Firebase by running the `firebase_app_distribution_login` action (or using one of the other [authentication methods](https://firebase.google.com/docs/app-distribution/android/distribute-fastlane#step_2_authenticate_with_firebase)):
+
+```no-highlight
+fastlane run firebase_app_distribution_login
+```
+
+Then add the `firebase_app_distribution` action to your lane:
 
 ```ruby
 lane :beta do
@@ -85,21 +99,15 @@ lane :beta do
     build_type: 'Release'
   )
 
-  crashlytics(
-    api_token: '[insert_key_here]',
-    build_secret: '[insert_secret_here]'
+  firebase_app_distribution(
+    app: "1:123456789:android:abcd1234",
+    groups: "qa-team, trusted-testers"
   )
   # ...
 end
 ```
 
-To get your API token, open the [organizations settings page](https://www.fabric.io/settings/organizations) and click on the API key and build secret links.
-
-Additionally you can specify `notes`, `emails`, `groups` and `notifications`. To get a list of all available options, run:
-
-```no-highlight
-fastlane action crashlytics
-```
+For more information and options (such as adding release notes) see the full [Getting Started](https://firebase.google.com/docs/app-distribution/android/distribute-fastlane) guide.
 
 ---
 </details>

--- a/docs/getting-started/ios/beta-deployment.md
+++ b/docs/getting-started/ios/beta-deployment.md
@@ -103,25 +103,36 @@ With _fastlane_, you can also automatically manage your beta testers, check out 
 </details>
 
 <details>
-<summary>Crashlytics (Fabric Beta)</summary>
+<summary>Firebase App Distribution</summary>
+
+Install the Firebase App Distribution plugin:
+
+```no-highlight
+fastlane add_plugin firebase_app_distribution
+```
+
+Authenticate with Firebase by running the `firebase_app_distribution_login` action (or using one of the other [authentication methods](https://firebase.google.com/docs/app-distribution/ios/distribute-fastlane#step_2_authenticate_with_firebase)):
+
+```no-highlight
+fastlane run firebase_app_distribution_login
+```
+
+Then add the `firebase_app_distribution` action to your lane:
 
 ```ruby
 lane :beta do
   # ...
   build_app
-  crashlytics(api_token: "[insert_key_here]",
-              build_secret: "[insert_key_here]")
+
+  firebase_app_distribution(
+    app: "1:123456789:ios:abcd1234",
+    groups: "qa-team, trusted-testers"
+  )
+  # ...
 end
 ```
 
-To get your API token, open the [organizations settings page](https://www.fabric.io/settings/organizations) and click on the API key and build secret links. 
-
-
-To get a list of all available options, run
-
-```no-highlight
-fastlane action crashlytics
-```
+For more information and options (such as adding release notes) see the full [Getting Started](https://firebase.google.com/docs/app-distribution/ios/distribute-fastlane) guide.
 
 ---
 </details>


### PR DESCRIPTION
The `crashlytics` action has been deprecated for months but is still listed as a beta deployment option. This swaps in its replacement, Firebase App Distribution, in its place.

iOS:
![image](https://user-images.githubusercontent.com/10420620/91849633-578f1d80-ec2a-11ea-806a-c40d1a03355b.png)

Android (identical except for gradle in place of build_app, and the docs link URLs):
![image](https://user-images.githubusercontent.com/10420620/91849671-62e24900-ec2a-11ea-82f0-6122467b8732.png)
