### PR TITLE
update “System requirements” section to clarify supported operating systems

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -75,6 +75,12 @@ Before submitting a new GitHub issue, please make sure to search for [existing G
 
 If that doesn't help, please [submit an issue](https://github.com/fastlane/fastlane/issues) on GitHub and provide information about your setup, in particular the output of the `fastlane env` command.
 
+## System requirements
+
+_fastlane_ is officially supported to run on macOS.
+
+🐧 Linux and 🖥️ Windows are partially supported. Some underlying software like Xcode are only available on macOS, but many other tools, actions, and the `spaceship` module can work on other platforms.
+
 ## _fastlane_ team
 
 <table>

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,12 +75,6 @@ Before submitting a new GitHub issue, please make sure to search for [existing G
 
 If that doesn't help, please [submit an issue](https://github.com/fastlane/fastlane/issues) on GitHub and provide information about your setup, in particular the output of the `fastlane env` command.
 
-## System requirements
-
-Currently, _fastlane_ is officially supported to run on macOS. 
-
-But we are working on 🐧 Linux and 🖥️ Windows support for parts of _fastlane_. Some underlying software like Xcode or iTunes Transporter is only available for macOS, but many other tools and actions can theoretically also work on other platforms. Please see [this Github issue for further information](https://github.com/fastlane/fastlane/issues/11687).
-
 ## _fastlane_ team
 
 <table>


### PR DESCRIPTION
Since https://github.com/fastlane/docs/pull/946, _fastlane_ officially supports macOS, Linux, and Windows. The [System requirements](https://github.com/fastlane/docs/blob/39c8b6edd183bae3b748e472b294724807fa9cec/docs/index.md#system-requirements) section still mentions only macOS and links to the already-closed https://github.com/fastlane/fastlane/issues/11687. Therefore, this section can arguably be removed altogether.