### PR TITLE
set jenkins-lts as the recommended way of installing Jenkins

### DIFF
--- a/docs/best-practices/continuous-integration/jenkins.md
+++ b/docs/best-practices/continuous-integration/jenkins.md
@@ -5,13 +5,13 @@
 The recommended way to install [Jenkins](http://jenkins-ci.org/) is through [homebrew](http://brew.sh/):
 
 ```no-highlight
-brew update && brew install jenkins
+brew update && brew install jenkins-lts
 ```
 
 From now on start `Jenkins` by running:
 
 ```no-highlight
-jenkins
+brew services start jenkins-lts
 ```
 
 To store the password in the Keychain of your remote machine, it is recommended that you run _match_ or _deliver_ using ssh or remote desktop at least once.

--- a/docs/best-practices/continuous-integration/jenkins.md
+++ b/docs/best-practices/continuous-integration/jenkins.md
@@ -2,7 +2,7 @@
 
 ## Installation
 
-The recommended way to install [Jenkins](http://jenkins-ci.org/) is through [homebrew](http://brew.sh/):
+The recommended way to [install Jenkins on macOS](https://www.jenkins.io/download/lts/macos/) is through [homebrew](http://brew.sh/):
 
 ```no-highlight
 brew update && brew install jenkins-lts


### PR DESCRIPTION
changed from jenkins to jenkins-lts as a recommended way of installing Jenkins

<!--
Thanks for contributing to _fastlane_! Before you submit your pull request, note that files in the docs folder covering Actions (actions.md and actions/*) and Plugins (available-plugins.md) are auto-generated.
If this is the case, please modify the documentation at their sources (https://github.com/fastlane/fastlane or plugin repository) and will be updated here regularly.
-->
