### PR TITLE
Fix link of guide "distributing beta builds for React Native projects"

### DIFF
--- a/docs/getting-started/cross-platform/react-native.md
+++ b/docs/getting-started/cross-platform/react-native.md
@@ -4,7 +4,7 @@ Most of the _fastlane_ docs on this page apply to React Native projects as well.
 
 As there is no official getting started guide yet, here are some publications by the _fastlane_ community:
 
-- [Distributing beta builds with Fastlane on Android and iOS](https://github.com/thecodingmachine/react-native-boilerplate/blob/master/docs/beta%20builds.md)
+- [Distributing beta builds with Fastlane on Android and iOS](https://thecodingmachine.github.io/react-native-boilerplate/docs/BetaBuild)
 - [Shipping React Native apps with fastlane](https://carloscuesta.me/blog/shipping-react-native-apps-with-fastlane/)
 - [React Native, fastlane and Visual Studio App Center](https://github.com/osamaq/reactnative-fastlane-appcenter)
 - [Conference talk "Automate your React Native world with fastlane"](https://www.youtube.com/watch?v=1K5OLv3moFg)


### PR DESCRIPTION
Same documentation but has just moved to a new url
