### PR TITLE
Set UI Test iOS Deployment Target

### DIFF
--- a/docs/actions/capture_ios_screenshots.md
+++ b/docs/actions/capture_ios_screenshots.md
@@ -94,7 +94,7 @@ Here a few links to get started:
 
 # Quick Start
 
-- Create a new UI Test target in your Xcode project ([top part of this article](https://krausefx.com/blog/run-xcode-7-ui-tests-from-the-command-line))
+- Create a new UI Test target in your Xcode project ([top part of this article](https://krausefx.com/blog/run-xcode-7-ui-tests-from-the-command-line)) and give it the same iOS Deployment Target setting as your project. 
 - Run `fastlane snapshot init` in your project folder
 - Add the ./SnapshotHelper.swift to your UI Test target (You can move the file anywhere you want)
   - (Xcode 8 only) add the ./SnapshotHelperXcode8.swift to your UI Test target


### PR DESCRIPTION
Set UI Test iOS Development Target to avoid fastlane issue.
Resolves https://github.com/fastlane/fastlane/issues/16277

Undefined symbols for architecture x86_64:
"_swift_getTypeByMangledNameInContextInMetadataState", referenced from:
___swift_instantiateConcreteTypeFromMangledNameAbstract in SnapshotHelper.o

<!--
Thanks for contributing to _fastlane_! Before you submit your pull request, note that files in the docs folder covering Actions (actions.md and actions/*) and Plugins (available-plugins.md) are auto-generated.
If this is the case, please modify the documentation at their sources (https://github.com/fastlane/fastlane or plugin repository) and will be updated here regularly.
-->
