### PR TITLE
Lock parallel at Ruby 1.19.2 to allow for Ruby 2.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,5 @@ source("https://rubygems.org")
 gem "danger"
 gem "fastlane", git: "https://github.com/fastlane/fastlane"
 gem "rubocop", "0.49.1"
+
+gem "parallel", "1.19.2" # 1.20.0 requires Ruby 2.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,7 +164,7 @@ GEM
       sawyer (~> 0.8.0, >= 0.5.3)
     open4 (1.3.4)
     os (1.1.1)
-    parallel (1.20.0)
+    parallel (1.19.2)
     parser (2.7.2.0)
       ast (~> 2.4.1)
     plist (3.5.0)
@@ -234,6 +234,7 @@ PLATFORMS
 DEPENDENCIES
   danger
   fastlane!
+  parallel (= 1.19.2)
   rubocop (= 0.49.1)
 
 BUNDLED WITH


### PR DESCRIPTION
Issue here - https://app.circleci.com/pipelines/github/fastlane/fastlane/1589/workflows/9b2d9dc0-2cf8-4743-a242-f47dbf6a3946/jobs/57177