### PR TITLE
Update installing-fastlane.md

### DIFF
--- a/docs/includes/installing-fastlane.md
+++ b/docs/includes/installing-fastlane.md
@@ -10,15 +10,28 @@ source "https://rubygems.org"
 
 gem "fastlane"
 ```
-- Run `[sudo] bundle update` and add both the `./Gemfile` and the `./Gemfile.lock` to version control
+- If you want the gems installed in a folder inside your project instead of globally in the system, so that you can avoid the need for `sudo`, you can run `bundle config set --local path 'vendor/bundle'`
+- Run
+  - Linux/Windows: `[sudo] bundle update`
+  - macOS: `[sudo] xcrun bundle update`
+- Add both the `./Gemfile` and the `./Gemfile.lock` to version control
 - Every time you run _fastlane_, use `bundle exec fastlane [lane]`
-- On your CI, add `[sudo] bundle install` as your first build step
-- To update _fastlane_, just run `[sudo] bundle update fastlane`
+- On your CI, add as your first build step
+  - Linux/Windows: `[sudo] bundle install`
+  - macOS: `[sudo] xcrun bundle install`
+- To update _fastlane_, just run
+  - Linux/Windows: `[sudo] bundle update fastlane`
+  - macOS: `[sudo] xcrun bundle update fastlane`
 
 #### RubyGems (macOS/Linux/Windows)
 
+##### Linux/Windows
 ```sh
 sudo gem install fastlane -NV
+```
+##### macOS
+```sh
+sudo xcrun gem install fastlane -NV
 ```
 
 #### Homebrew (macOS)


### PR DESCRIPTION
Update install documentation to reflect breaking changes in Xcode.

Now headers are not included anymore in the MacOS provided Ruby installation, so dependencies that need to build native extensions would throw an error and make the install fail. Now all the Ruby related commands need to pass through Xcode via `xcrun` (see comment in issue https://github.com/fastlane/fastlane/issues/15183#issuecomment-543844264).
I think this way is cleaner than installing another version of Ruby that could cause conflict with the preinstalled one.

Talking about cleanliness, I included an extra optional step to install dependencies in the project folder instead of system wide, to avoid the need to use sudo and to avoid cluttering system folders. I personally prefer this approach for cleanliness and safety both, so I think it's nice to tell there's this option too.

I came to this conclusions after some hours of research on the web and reading various docs, btw any further advice is welcome!

<!--
Thanks for contributing to _fastlane_! Before you submit your pull request, note that files in the docs folder covering Actions (actions.md and actions/*) and Plugins (available-plugins.md) are auto-generated.
If this is the case, please modify the documentation at their sources (https://github.com/fastlane/fastlane or plugin repository) and will be updated here regularly.
-->
