### PR TITLE
Add supported Ruby versions and deprecate "sudo gem install" to system Ruby

### DIFF
--- a/docs/includes/installing-fastlane.md
+++ b/docs/includes/installing-fastlane.md
@@ -1,4 +1,4 @@
-_fastlane_ can be installed multiple ways. The preferred method is with _Bundler_. _fastlane_ can also get installed directly through with Homebrew (if on macOS). Technically, you can use macOS's system Ruby but it's not recommended unless you are experienced Ruby developer.
+_fastlane_ can be installed multiple ways. The preferred method is with [_Bundler_](https://bundler.io). _fastlane_ can also be installed directly through with Homebrew (if on macOS). Technically, you can use macOS's system Ruby but it's not recommended unless you are a experienced Ruby developer.
 
 #### Managed Ruby environment + Bundler (macOS/Linux/Windows)
 

--- a/docs/includes/installing-fastlane.md
+++ b/docs/includes/installing-fastlane.md
@@ -40,7 +40,7 @@ brew install fastlane
 
 #### System Ruby + RubyGems (macOS/Linux/Windows)
 
-This is not recommended for your local environment but you can still install _fastlane_ to system Ruby's environment. Using `sudo` often occurs unwanted results later due to file permission and makes managing your environment harder.
+This is not recommended for your local environment, but you can still install _fastlane_ to system Ruby's environment. Using `sudo` often occurs unwanted results later due to file permission and makes managing your environment harder.
 
 ```sh
 sudo gem install fastlane

--- a/docs/includes/installing-fastlane.md
+++ b/docs/includes/installing-fastlane.md
@@ -4,7 +4,7 @@ _fastlane_ can be installed multiple ways. The preferred method is with [_Bundle
 
 **Ruby**
 
-If you use macOS, please don't use system Ruby when possible. [There is a variety of ways to install Ruby without having to modify your system environment](https://www.ruby-lang.org/en/documentation/installation/#managers). For macOS and Linux, _rbenv_ is one of the most popular ways to manage your Ruby environment.
+If you use macOS, system Ruby is not recommended. [There is a variety of ways to install Ruby without having to modify your system environment](https://www.ruby-lang.org/en/documentation/installation/#managers). For macOS and Linux, _rbenv_ is one of the most popular ways to manage your Ruby environment.
 
 _fastlane_ supports Ruby versions 2.4 through 2.7. Verify which Ruby version you're using:
 

--- a/docs/includes/installing-fastlane.md
+++ b/docs/includes/installing-fastlane.md
@@ -6,7 +6,7 @@ _fastlane_ can be installed multiple ways. The preferred method is with [_Bundle
 
 If you use macOS, please don't use system Ruby when possible. [There is a variety of ways to install Ruby without having to modify your system environment](https://www.ruby-lang.org/en/documentation/installation/#managers). For macOS and Linux, _rbenv_ is one of the most popular ways to manage your Ruby environment.
 
-You can use Ruby 2.4 - 2.7. Verify that you have a current version of Ruby installed:
+_fastlane_ supports Ruby versions 2.4 through 2.7. Verify which Ruby version you're using:
 
 ```sh
 $ ruby --version

--- a/docs/includes/installing-fastlane.md
+++ b/docs/includes/installing-fastlane.md
@@ -1,4 +1,4 @@
-_fastlane_ can be installed multiple ways. The preferred method is with [_Bundler_](https://bundler.io). _fastlane_ can also be installed directly through with Homebrew (if on macOS). Technically, you can use macOS's system Ruby but it's not recommended unless you are a experienced Ruby developer.
+_fastlane_ can be installed multiple ways. The preferred method is with [_Bundler_](https://bundler.io). _fastlane_ can also be installed directly through with Homebrew (if on macOS). It is possible to use macOS's system Ruby but it's not recommended as it can be hard to manage dependencies and cause conflicts.
 
 #### Managed Ruby environment + Bundler (macOS/Linux/Windows)
 

--- a/docs/includes/installing-fastlane.md
+++ b/docs/includes/installing-fastlane.md
@@ -17,7 +17,7 @@ ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-darwin19]
 
 It is recommended that you use _Bundler_ and `Gemfile` to define your dependency on _fastlane_. This will clearly define the  _fastlane_ version to be used and its dependencies, and will also speed up _fastlane_ execution.
 
-- Install _bundler_ itself by `gem install bundler`
+- Install _Bundler_ by running `gem install bundler`
 - Create a `./Gemfile` in the root directory of your project with the content
 ```ruby
 source "https://rubygems.org"

--- a/docs/includes/installing-fastlane.md
+++ b/docs/includes/installing-fastlane.md
@@ -15,7 +15,7 @@ ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-darwin19]
 
 **Bundler**
 
-It is recommended that you use _Bundler_ and `Gemfile` to define your dependency on _fastlane_. This will clearly define the  _fastlane_ version to be used and its dependencies, and will also speed up _fastlane_ execution.
+It is recommended that you use _Bundler_ and `Gemfile` to define your dependency on _fastlane_. This will clearly define the _fastlane_ version to be used and its dependencies, and will also speed up _fastlane_ execution.
 
 - Install _Bundler_ by running `gem install bundler`
 - Create a `./Gemfile` in the root directory of your project with the content

--- a/docs/includes/installing-fastlane.md
+++ b/docs/includes/installing-fastlane.md
@@ -4,7 +4,7 @@ _fastlane_ can be installed multiple ways. The preferred method is with [_Bundle
 
 **Ruby**
 
-If you use macOS, please don't use system Ruby when possible. [There is a variety of ways to install Ruby without having to modify your system environment](https://www.ruby-lang.org/en/documentation/installation/#managers). For macOS and Linux, _rbenv_ would be one of the most popular way to manage your Ruby environment.
+If you use macOS, please don't use system Ruby when possible. [There is a variety of ways to install Ruby without having to modify your system environment](https://www.ruby-lang.org/en/documentation/installation/#managers). For macOS and Linux, _rbenv_ is one of the most popular ways to manage your Ruby environment.
 
 You can use Ruby 2.4 - 2.7. Verify that you have a current version of Ruby installed:
 

--- a/docs/includes/installing-fastlane.md
+++ b/docs/includes/installing-fastlane.md
@@ -1,28 +1,47 @@
-_fastlane_ can be installed multiple ways. The preferred method is with a `Gemfile`. _fastlane_ can also get installed directly through RubyGems or with Homebrew (if on macOS).
+_fastlane_ can be installed multiple ways. The preferred method is with _Bundler_. _fastlane_ can also get installed directly through with Homebrew (if on macOS). Technically, you can use macOS's system Ruby but it's not recommended unless you are experienced Ruby developer.
 
-#### A Gemfile (macOS/Linux/Windows)
+#### Managed Ruby environment + Bundler (macOS/Linux/Windows)
 
-It is recommended that you use a `Gemfile` to define your dependency on _fastlane_. This will clearly define the used _fastlane_ version, and its dependencies, and will also speed up using _fastlane_.
+**Ruby**
 
+If you use macOS, please don't use system Ruby when possible. [There is a variety of ways to install Ruby without having to modify your system environment](https://www.ruby-lang.org/en/documentation/installation/#managers). For macOS and Linux, _rbenv_ would be one of the most popular way to manage your Ruby environment.
+
+You can use Ruby 2.4 - 2.7. Verify that you have a current version of Ruby installed:
+
+```sh
+$ ruby --version
+ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-darwin19]
+```
+
+**Bundler**
+
+It is recommended that you use `bundler` and `Gemfile` to define your dependency on _fastlane_. This will clearly define the used _fastlane_ version, and its dependencies, and will also speed up using _fastlane_.
+
+- Install _bundler_ itself by `gem install bundler`
 - Create a `./Gemfile` in the root directory of your project with the content
 ```ruby
 source "https://rubygems.org"
 
 gem "fastlane"
 ```
-- Run `[sudo] bundle update` and add both the `./Gemfile` and the `./Gemfile.lock` to version control
+- Run `bundle update` and add both the `./Gemfile` and the `./Gemfile.lock` to version control
 - Every time you run _fastlane_, use `bundle exec fastlane [lane]`
-- On your CI, add `[sudo] bundle install` as your first build step
-- To update _fastlane_, just run `[sudo] bundle update fastlane`
-
-#### RubyGems (macOS/Linux/Windows)
-
-```sh
-sudo gem install fastlane -NV
-```
+- On your CI, add `bundle install` as your first build step
+- To update _fastlane_, just run `bundle update fastlane`
 
 #### Homebrew (macOS)
 
+This way you don't have to install Ruby separately and instead _homebrew_ install sthe best Ruby version alongside _fastlane_.
+See [this page](https://formulae.brew.sh/formula/fastlane) for details.
+
 ```sh
 brew install fastlane
+```
+
+#### System Ruby + RubyGems (macOS/Linux/Windows)
+
+This is not recommended for your local environment but you can still install _fastlane_ to system Ruby's environment. Using `sudo` often occurs unwanted results later due to file permission and makes managing your environment harder.
+
+```sh
+sudo gem install fastlane
 ```

--- a/docs/includes/installing-fastlane.md
+++ b/docs/includes/installing-fastlane.md
@@ -31,7 +31,7 @@ gem "fastlane"
 
 #### Homebrew (macOS)
 
-This way you don't have to install Ruby separately and instead _homebrew_ install sthe best Ruby version alongside _fastlane_.
+This way you don't have to install Ruby separately and instead _homebrew_ installs the most adequate Ruby version for _fastlane_.
 See [this page](https://formulae.brew.sh/formula/fastlane) for details.
 
 ```sh

--- a/docs/includes/installing-fastlane.md
+++ b/docs/includes/installing-fastlane.md
@@ -15,7 +15,7 @@ ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-darwin19]
 
 **Bundler**
 
-It is recommended that you use `bundler` and `Gemfile` to define your dependency on _fastlane_. This will clearly define the used _fastlane_ version, and its dependencies, and will also speed up using _fastlane_.
+It is recommended that you use _Bundler_ and `Gemfile` to define your dependency on _fastlane_. This will clearly define the  _fastlane_ version to be used and its dependencies, and will also speed up _fastlane_ execution.
 
 - Install _bundler_ itself by `gem install bundler`
 - Create a `./Gemfile` in the root directory of your project with the content


### PR DESCRIPTION
<!--
Thanks for contributing to _fastlane_! Before you submit your pull request, note that files in the docs folder covering Actions (actions.md and actions/*) and Plugins (available-plugins.md) are auto-generated.
If this is the case, please modify the documentation at their sources (https://github.com/fastlane/fastlane or plugin repository) and will be updated here regularly.
-->

Closes fastlane/docs#1018

Last year Ruby 3.0 was released and I started working on Ruby 3.0 migration project lately. I realised that not a few people pick up Ruby 3.0 as their first Ruby version to install and get errors.  https://github.com/fastlane/fastlane/issues/17931

Right now if you try `gem install fastlane` with Ruby 3.0,  it results in getting version "2.54.1", which is too old. We've gotten several issues due to that. To clarify supported versions, I updated the installation guide page. 

And also there is something bugging me always, which is recommending using "sudo". It's almost common sense among Ruby developers, which we should avoid using system's Ruby and should adopt some manager solution for local Ruby environment. So I tried updating that part as well. 

I know Ruby environment for mobile app developers is not as important as for web developers but wanted to stop recommending system Ruby + "sudo" at least, which makes us even harder to track GitHub issues; e.g. https://github.com/fastlane/fastlane/issues/15183#issuecomment-543844264

In addition, Apple clearly mentioned that macOS won't include Ruby in future. We will need to admit this anyway. 

> Scripting language runtimes such as Python, Ruby, and Perl are included in macOS for compatibility with legacy software. Future versions of macOS won’t include scripting language runtimes by default, and might require you to install additional packages. If your software depends on scripting languages, it’s recommended that you bundle the runtime within the app. (49764202)

https://developer.apple.com/documentation/macos-release-notes/macos-catalina-10_15-release-notes