### PR TITLE
clarify description of `development` option of sigh action

### DIFF
--- a/docs/actions/sigh.md
+++ b/docs/actions/sigh.md
@@ -274,7 +274,7 @@ Key | Description | Default
 ----|-------------|--------
   `adhoc` | Setting this flag will generate AdHoc profiles instead of App Store Profiles | `false`
   `developer_id` | Setting this flag will generate Developer ID profiles instead of App Store Profiles | `false`
-  `development` | Renew the development certificate instead of the production one | `false`
+  `development` | Renew the development profile instead of the production one | `false`
   `skip_install` | By default, the certificate will be added to your local machine. Setting this flag will skip this action | `false`
   `force` | Renew provisioning profiles regardless of its state - to automatically add all devices for ad hoc profiles | `false`
   `app_identifier` | The bundle identifier of your app | [*](#parameters-legend-dynamic)


### PR DESCRIPTION
Clarifies the `development` parameter, that it refreshes the development profile instead of the certificate.

<!--
Thanks for contributing to _fastlane_! Before you submit your pull request, note that files in the docs folder covering Actions (actions.md and actions/*) and Plugins (available-plugins.md) are auto-generated.
If this is the case, please modify the documentation at their sources (https://github.com/fastlane/fastlane or plugin repository) and will be updated here regularly.
-->
