### PR TITLE
document the fact that App Store Connect API sessions max duration is 20 minutes

### DIFF
--- a/docs/app-store-connect-api.md
+++ b/docs/app-store-connect-api.md
@@ -55,7 +55,7 @@ lane :release do
     key_id: "D383SF739",
     issuer_id: "6053b7fe-68a8-4acb-89be-165aa6465141",
     key_filepath: "./AuthKey_D383SF739.p8",
-    duration: 1200, # optional
+    duration: 1200, # optional (maximum 1200)
     in_house: false, # optional but may be required if using match/sigh
   )
 
@@ -73,7 +73,7 @@ lane :release do
     key_id: "D383SF739",
     issuer_id: "6053b7fe-68a8-4acb-89be-165aa6465141",
     key_filepath: "./AuthKey_D383SF739.p8",
-    duration: 1200, # optional
+    duration: 1200, # optional (maximum 1200)
     in_house: false, # optional but may be required if using match/sigh
   )
 
@@ -92,7 +92,7 @@ Below is an example of the _fastlane_ API Key JSON file format that tools and ac
 
 The JSON file allows optional:
 
-- `duration` (session length in seconds)
+- `duration` (session length in seconds, maximum 1200)
 - `in_house` (boolean value if team is Enterprise or not)
 
 ```js
@@ -100,7 +100,7 @@ The JSON file allows optional:
   "key_id": "D383SF739",
   "issuer_id": "6053b7fe-68a8-4acb-89be-165aa6465141",
   "key": "-----BEGIN PRIVATE KEY-----\nMIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHknlhdlYdLu\n-----END PRIVATE KEY-----",
-  "duration": 1200, # optional
+  "duration": 1200, # optional (maximum 1200)
   "in_house": false, # optional but may be required if using match/sigh
 }
 ```


### PR DESCRIPTION
Clarify that maximum session length is 1200 seconds (20 min) as mentioned in the app store api docs https://developer.apple.com/documentation/appstoreconnectapi/generating_tokens_for_api_requests

If set to a higher number fastlane will output the following error. It would be great with a code check for this as well with a more friendly error message.

```
[!] The request could not be completed because:
        Authentication credentials are missing or invalid. - Provide a properly configured and signed bearer token, and make sure that it has not expired. Learn more about Generating Tokens for API Requests https://developer.apple.com/go/?id=api-generating-tokens
```

<!--
Thanks for contributing to _fastlane_! Before you submit your pull request, note that files in the docs folder covering Actions (actions.md and actions/*) and Plugins (available-plugins.md) are auto-generated.
If this is the case, please modify the documentation at their sources (https://github.com/fastlane/fastlane or plugin repository) and will be updated here regularly.
-->
