### PR TITLE
fix deploy that is failing due to incompatible Ruby version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.0
 jobs:
   "Test":
     docker:
-      - image: fastlanetools/ci:0.2.0
+      - image: fastlanetools/ci:0.3.0
     working_directory: ~/code
     steps:
       - checkout
@@ -16,7 +16,7 @@ jobs:
       - run: bundle exec danger || echo "danger failed, moving on"
   "Deploy":
     docker:
-      - image: fastlanetools/ci:0.2.0
+      - image: fastlanetools/ci:0.3.0
     working_directory: ~/code
     steps:
       - checkout

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,4 @@ source("https://rubygems.org")
 # We want to test with the latest master branch
 gem "danger"
 gem "fastlane", git: "https://github.com/fastlane/fastlane"
-gem "parallel", "<1.20.0" # 1.20.0 requires Ruby 2.5
 gem "rubocop", "0.49.1"
-gem "signet", "<0.15.0" # 0.15.0 requires Ruby 2.5

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ source("https://rubygems.org")
 gem "danger"
 gem "fastlane", git: "https://github.com/fastlane/fastlane"
 gem "rubocop", "0.49.1"
-
-gem "parallel", "1.19.2" # 1.20.0 requires Ruby 2.5
+gem "signet", "<0.15.0" # 0.15.0 requires Ruby 2.5
+gem "parallel", "<1.20.0" # 1.20.0 requires Ruby 2.5

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source("https://rubygems.org")
 # We want to test with the latest master branch
 gem "danger"
 gem "fastlane", git: "https://github.com/fastlane/fastlane"
-gem "rubocop", "0.49.1"
 gem "parallel", "<1.20.0" # 1.20.0 requires Ruby 2.5
+gem "rubocop", "0.49.1"
 gem "signet", "<0.15.0" # 0.15.0 requires Ruby 2.5

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ source("https://rubygems.org")
 gem "danger"
 gem "fastlane", git: "https://github.com/fastlane/fastlane"
 gem "rubocop", "0.49.1"
-gem "signet", "<0.15.0" # 0.15.0 requires Ruby 2.5
 gem "parallel", "<1.20.0" # 1.20.0 requires Ruby 2.5
+gem "signet", "<0.15.0" # 0.15.0 requires Ruby 2.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,7 +215,7 @@ GEM
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
     security (0.1.3)
-    signet (0.15.0)
+    signet (0.14.1)
       addressable (~> 2.3)
       faraday (>= 0.17.3, < 2.0)
       jwt (>= 1.5, < 3.0)
@@ -255,8 +255,9 @@ PLATFORMS
 DEPENDENCIES
   danger
   fastlane!
-  parallel (= 1.19.2)
+  parallel (< 1.20.0)
   rubocop (= 0.49.1)
+  signet (< 0.15.0)
 
 BUNDLED WITH
-   2.2.8
+   2.2.14

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/fastlane/fastlane
-  revision: 200cf8f82d4f760bc693d64f294decf92ecfa9d7
+  revision: 6702e2eeef1f383b3627b940f6e6c76d4ebc1551
   specs:
     fastlane (2.177.0)
       CFPropertyList (>= 2.3, < 4.0.0)
@@ -51,16 +51,16 @@ GEM
     ast (2.4.2)
     atomos (0.1.3)
     aws-eventstream (1.1.1)
-    aws-partitions (1.431.1)
-    aws-sdk-core (3.112.1)
+    aws-partitions (1.432.0)
+    aws-sdk-core (3.113.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.42.0)
+    aws-sdk-kms (1.43.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.89.0)
+    aws-sdk-s3 (1.91.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
@@ -78,7 +78,7 @@ GEM
       highline (~> 1.7.2)
     cork (0.3.0)
       colored2 (~> 3.1)
-    danger (8.2.2)
+    danger (8.2.3)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
       colored2 (~> 3.1)
@@ -90,7 +90,7 @@ GEM
       kramdown-parser-gfm (~> 1.0)
       no_proxy_fix
       octokit (~> 4.7)
-      terminal-table (~> 1)
+      terminal-table (>= 1, < 4)
     declarative (0.0.20)
     declarative-option (0.1.0)
     digest-crc (0.6.3)
@@ -138,13 +138,13 @@ GEM
       google-apis-core (~> 0.1)
     google-apis-storage_v1 (0.3.0)
       google-apis-core (~> 0.1)
-    google-cloud-core (1.5.0)
+    google-cloud-core (1.6.0)
       google-cloud-env (~> 1.0)
       google-cloud-errors (~> 1.0)
-    google-cloud-env (1.4.0)
+    google-cloud-env (1.5.0)
       faraday (>= 0.17.3, < 2.0)
-    google-cloud-errors (1.0.1)
-    google-cloud-storage (1.30.0)
+    google-cloud-errors (1.1.0)
+    google-cloud-storage (1.31.0)
       addressable (~> 2.5)
       digest-crc (~> 0.4)
       google-apis-iamcredentials_v1 (~> 0.1)
@@ -184,7 +184,7 @@ GEM
       sawyer (~> 0.8.0, >= 0.5.3)
     open4 (1.3.4)
     os (1.1.1)
-    parallel (1.19.2)
+    parallel (1.20.1)
     parser (2.7.2.0)
       ast (~> 2.4.1)
     plist (3.6.0)
@@ -215,7 +215,7 @@ GEM
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
     security (0.1.3)
-    signet (0.14.1)
+    signet (0.15.0)
       addressable (~> 2.3)
       faraday (>= 0.17.3, < 2.0)
       jwt (>= 1.5, < 3.0)
@@ -255,9 +255,7 @@ PLATFORMS
 DEPENDENCIES
   danger
   fastlane!
-  parallel (< 1.20.0)
   rubocop (= 0.49.1)
-  signet (< 0.15.0)
 
 BUNDLED WITH
    2.2.14

--- a/docs/includes/google-credentials.md
+++ b/docs/includes/google-credentials.md
@@ -1,25 +1,19 @@
 Tip: If you see Google Play Console or Google Developer Console in your local language, add `&hl=en` at the end of the URL (before any `#...`) to switch to English.
 
-Settings → Developer Account → API access
-Create new service account
-
-
-1. Open the [Google Play Console]("https://play.google.com/apps/publish/")
-1. Click **Settings** → **Developer Account** → **API access**
-1. Click the **Create new service account** button
+1. Open the [Google Play Console](https://play.google.com/apps/publish/)
+1. Click the **Settings** menu entry, followed by **API access**
+1. Click the **CREATE SERVICE ACCOUNT** button 
 1. Follow the **Google Developers Console** link in the dialog, which opens a new tab/window:
    1. Click the **CREATE SERVICE ACCOUNT** button at the top of the **Google Developers Console**
-   1. Provide a `Service account name` and click **Create**
-   1. Click **Select a role**, then find and select **Service Account User**, and proceed.
-   1. Click the **Done** button
-   1. Click on the **Actions** vertical three-dot icon of the service account you just created
-   1. Select **Manage keys** on the menu
-   1. Click **ADD KEY** -> **Create New Key**
-   1. Make sure **JSON** is selected as the `Key type`, and click **CREATE**
-   1. Save the file on your computer when prompted and remember where it was saved to
+   1. Provide a `Service account name`
+   1. Click **Select a role** and choose **Service Accounts > Service Account User**
+   1. Check the **Furnish a new private key** checkbox
+   1. Make sure **JSON** is selected as the `Key type`
+   1. Click **SAVE** to close the dialog
+   1. Make a note of the file name of the JSON file downloaded to your computer
 1. Back on the **Google Play Console**, click **DONE** to close the dialog
-1. Click on **Grant Access** for the newly added service account at the bottom of the screen
-1. Choose the permissions you'd like this account to have. We recommend **Admin (all permissions)**, but you may want to manually select all checkboxes and leave out some of the **Releases** permissions such as **Release to production**.
-1. Click **Invite user** to finish.
+1. Click on **Grant Access** for the newly added service account
+1. Choose **Release Manager** (or alternatively **Project Lead**) from the `Role` dropdown. (Note that choosing **Release Manager** grants access to the production track and all other tracks. Choosing **Project Lead** grants access to update all tracks _except_ the production track.)
+1. Click **ADD USER** to close the dialog
 
 You can use [`fastlane run validate_play_store_json_key json_key:/path/to/your/downloaded/file.json`](https://docs.fastlane.tools/actions/validate_play_store_json_key/) to test the connection to Google Play Store with the downloaded private key.

--- a/docs/includes/google-credentials.md
+++ b/docs/includes/google-credentials.md
@@ -1,19 +1,25 @@
 Tip: If you see Google Play Console or Google Developer Console in your local language, add `&hl=en` at the end of the URL (before any `#...`) to switch to English.
 
-1. Open the [Google Play Console](https://play.google.com/apps/publish/)
-1. Click the **Settings** menu entry, followed by **API access**
-1. Click the **CREATE SERVICE ACCOUNT** button 
+Settings → Developer Account → API access
+Create new service account
+
+
+1. Open the [Google Play Console]("https://play.google.com/apps/publish/")
+1. Click **Settings** → **Developer Account** → **API access**
+1. Click the **Create new service account** button
 1. Follow the **Google Developers Console** link in the dialog, which opens a new tab/window:
    1. Click the **CREATE SERVICE ACCOUNT** button at the top of the **Google Developers Console**
-   1. Provide a `Service account name`
-   1. Click **Select a role** and choose **Service Accounts > Service Account User**
-   1. Check the **Furnish a new private key** checkbox
-   1. Make sure **JSON** is selected as the `Key type`
-   1. Click **SAVE** to close the dialog
-   1. Make a note of the file name of the JSON file downloaded to your computer
+   1. Provide a `Service account name` and click **Create**
+   1. Click **Select a role**, then find and select **Service Account User**, and proceed.
+   1. Click the **Done** button
+   1. Click on the **Actions** vertical three-dot icon of the service account you just created
+   1. Select **Manage keys** on the menu
+   1. Click **ADD KEY** -> **Create New Key**
+   1. Make sure **JSON** is selected as the `Key type`, and click **CREATE**
+   1. Save the file on your computer when prompted and remember where it was saved to
 1. Back on the **Google Play Console**, click **DONE** to close the dialog
-1. Click on **Grant Access** for the newly added service account
-1. Choose **Release Manager** (or alternatively **Project Lead**) from the `Role` dropdown. (Note that choosing **Release Manager** grants access to the production track and all other tracks. Choosing **Project Lead** grants access to update all tracks _except_ the production track.)
-1. Click **ADD USER** to close the dialog
+1. Click on **Grant Access** for the newly added service account at the bottom of the screen
+1. Choose the permissions you'd like this account to have. We recommend **Admin (all permissions)**, but you may want to manually select all checkboxes and leave out some of the **Releases** permissions such as **Release to production**.
+1. Click **Invite user** to finish.
 
 You can use [`fastlane run validate_play_store_json_key json_key:/path/to/your/downloaded/file.json`](https://docs.fastlane.tools/actions/validate_play_store_json_key/) to test the connection to Google Play Store with the downloaded private key.


### PR DESCRIPTION
This PR fixes this deploy issue:

<img width="694" alt="image" src="https://user-images.githubusercontent.com/8419048/110568615-05c3d480-8132-11eb-9c5d-93016d020684.png">


`signet` was upgraded here https://github.com/fastlane/docs/pull/1033/files#diff-89cade48462044ee1b672dc5f4c3ec250fbd29effcd8932096a23c1283c6731fR218 and CI started failing to deploy. This simple constrain of gem version should do the trick for now until we decide to upgrade Ruby.


Link to first deploy build that saw this failure: https://app.circleci.com/pipelines/github/fastlane/docs/290/workflows/7699c289-8361-4d3f-bd1f-767a42cd0969/jobs/2714
Link to another one: https://app.circleci.com/pipelines/github/fastlane/docs/292/workflows/434bd003-af32-4bca-95d2-2598df4f7281/jobs/2720
