### PR TITLE
Fix Typo in setup.md

### DIFF
--- a/docs/includes/google-credentials.md
+++ b/docs/includes/google-credentials.md
@@ -23,5 +23,5 @@ You can use [`fastlane run validate_play_store_json_key json_key:/path/to/your/d
 ```ruby
 json_key_file("path/to/your/play-store-credentials.json")
 package_name("my.package.name")
-
+```
 The path is relative to where you normally run `fastlane`.


### PR DESCRIPTION
<!--
Thanks for contributing to _fastlane_! Before you submit your pull request, note that files in the docs folder covering Actions (actions.md and actions/*) and Plugins (available-plugins.md) are auto-generated.
If this is the case, please modify the documentation at their sources (https://github.com/fastlane/fastlane or plugin repository) and will be updated here regularly.
-->

In the current documentation, we have the below. https://docs.fastlane.tools/getting-started/android/setup/#collect-your-google-credentials
-- --

```
json_key_file("path/to/your/play-store-credentials.json")
package_name("my.package.name")


The path is relative to where you normally run `fastlane`.

### Configure _supply_

Edit your `fastlane/Appfile` and change the `json_key_file` line to have the path to your credentials file:

```ruby
json_key_file "/path/to/your/downloaded/key.json"
```
.
.
.
I think that the **Google Credentials** and **Configure _supply_** steps are mixed together when they should be separate steps. I believe that this should be changed to something like the below.
-- --
```
json_key_file("path/to/your/play-store-credentials.json")
package_name("my.package.name")
```

The path is relative to where you normally run `fastlane`.

### Configure _supply_

Edit your `fastlane/Appfile` and change the `json_key_file` line to have the path to your credentials file:

```
ruby
json_key_file "/path/to/your/downloaded/key.json"
```