### PR TITLE
Fix markdown not parsed in foldable details

### DIFF
--- a/docs/actions/appstore.md
+++ b/docs/actions/appstore.md
@@ -117,7 +117,7 @@ deliver(
 
 ## More options
 
-<details>
+<details markdown="1">
 <summary>View all available options and their valid values</summary>
 
 ## Available options
@@ -527,7 +527,7 @@ Key | Editable While Live | Directory | Filename | Deprecated Filename
 
 ## Reference
 
-<details>
+<details markdown="1">
 <summary>View all available categories, etc.</summary>
 
 ### Available Categories

--- a/docs/actions/capture_android_screenshots.md
+++ b/docs/actions/capture_android_screenshots.md
@@ -260,7 +260,7 @@ new CleanStatusBar()
 
 # Advanced _screengrab_
 
-<details>
+<details markdown="1">
 <summary>Launch Arguments</summary>
 
 You can provide additional arguments to your test cases on launch. These strings will be available in your tests through `InstrumentationRegistry.getArguments()`.
@@ -290,7 +290,7 @@ if (extras != null) {
 ```
 </details>
 
-<details>
+<details markdown="1">
 <summary>Detecting screengrab at runtime</summary>
 
 For some apps, it is helpful to know when _screengrab_ is running so that you can display specific data for your screenshots. For iOS fastlane users, this is much like "FASTLANE_SNAPSHOT". In order to do this, you'll need to have at least two product flavors of your app.

--- a/docs/actions/deliver.md
+++ b/docs/actions/deliver.md
@@ -117,7 +117,7 @@ deliver(
 
 ## More options
 
-<details>
+<details markdown="1">
 <summary>View all available options and their valid values</summary>
 
 ## Available options
@@ -527,7 +527,7 @@ Key | Editable While Live | Directory | Filename | Deprecated Filename
 
 ## Reference
 
-<details>
+<details markdown="1">
 <summary>View all available categories, etc.</summary>
 
 ### Available Categories

--- a/docs/actions/screengrab.md
+++ b/docs/actions/screengrab.md
@@ -260,7 +260,7 @@ new CleanStatusBar()
 
 # Advanced _screengrab_
 
-<details>
+<details markdown="1">
 <summary>Launch Arguments</summary>
 
 You can provide additional arguments to your test cases on launch. These strings will be available in your tests through `InstrumentationRegistry.getArguments()`.
@@ -290,7 +290,7 @@ if (extras != null) {
 ```
 </details>
 
-<details>
+<details markdown="1">
 <summary>Detecting screengrab at runtime</summary>
 
 For some apps, it is helpful to know when _screengrab_ is running so that you can display specific data for your screenshots. For iOS fastlane users, this is much like "FASTLANE_SNAPSHOT". In order to do this, you'll need to have at least two product flavors of your app.

--- a/docs/actions/upload_to_app_store.md
+++ b/docs/actions/upload_to_app_store.md
@@ -117,7 +117,7 @@ deliver(
 
 ## More options
 
-<details>
+<details markdown="1">
 <summary>View all available options and their valid values</summary>
 
 ## Available options
@@ -527,7 +527,7 @@ Key | Editable While Live | Directory | Filename | Deprecated Filename
 
 ## Reference
 
-<details>
+<details markdown="1">
 <summary>View all available categories, etc.</summary>
 
 ### Available Categories

--- a/docs/advanced/other.md
+++ b/docs/advanced/other.md
@@ -61,7 +61,7 @@ For example, _fastlane_ requires admin access to the Apple Developer account to 
 
 > **Warning:** Manually editing your _match_ repo can introduce unexpected behavior and is not recommended. Proceed with caution.
 
-<details>
+<details markdown="1">
 <summary>Instructions</summary>
 
 

--- a/docs/getting-started/android/beta-deployment.md
+++ b/docs/getting-started/android/beta-deployment.md
@@ -48,7 +48,7 @@ end
 
 ### Supported beta testing services
 
-<details>
+<details markdown="1">
 <summary>Google Play</summary>
 
 In order to distribute to Google Play with _upload_to_play_store_ you will need to have your Google credentials set up. Make sure you've gone through [Setting up _supply_](setup/#setting-up-supply) before continuing!
@@ -74,7 +74,7 @@ fastlane action upload_to_play_store
 ---
 </details>
 
-<details>
+<details markdown="1">
 <summary>Firebase App Distribution</summary>
 
 Install the Firebase App Distribution plugin:
@@ -116,7 +116,7 @@ More information about additional supported beta testing services can be found i
 
 ## Release Notes
 
-<details>
+<details markdown="1">
 <summary>Generate based on Git commits</summary>
 
 You take the time to write great Git commit messages, right? Why not take advantage of them to automatically summarize the work done for your latest beta release?
@@ -147,7 +147,7 @@ changelog_from_git_commits(
 ---
 </details>
 
-<details>
+<details markdown="1">
 <summary>Prompt for changelog</summary>
 
 You can automatically be asked for the changelog in your terminal using the `prompt` action:
@@ -175,7 +175,7 @@ end
 ---
 </details>
 
-<details>
+<details markdown="1">
 <summary>Fetch the changelog from the file system or remote server</summary>
 
 You can fetch values from anywhere, including the file system and remote server, by writing code in your `Fastfile`

--- a/docs/getting-started/android/screenshots.md
+++ b/docs/getting-started/android/screenshots.md
@@ -183,7 +183,7 @@ fastlane action upload_to_play_store
 
 ## Advanced _screengrab_
 
-<details>
+<details markdown="1">
 <summary>Launch Arguments</summary>
 
 You can provide additional arguments to your testcases on launch. These strings will be available in your tests through `InstrumentationRegistry.getArguments()`.

--- a/docs/getting-started/ios/appstore-deployment.md
+++ b/docs/getting-started/ios/appstore-deployment.md
@@ -64,7 +64,7 @@ For more details on how `upload_to_app_store` works, how you can define more opt
 
 ## Best Practices
 
-<details>
+<details markdown="1">
 <summary>Push Notifications</summary>
 
 To make sure your latest push notification certificate is still valid during your submission process, add the following at the beginning of your lane:
@@ -82,7 +82,7 @@ If you don't have any push certificates already, _get_push_certificate_ will cre
 
 </details>
 
-<details>
+<details markdown="1">
 <summary>Incrementing the build number</summary>
 
 The code sample below will use the latest build number from App Store Connect and temporarily set it. 

--- a/docs/getting-started/ios/beta-deployment.md
+++ b/docs/getting-started/ios/beta-deployment.md
@@ -59,7 +59,7 @@ fastlane action slack
 #### Beta testing services
 
 
-<details>
+<details markdown="1">
 <summary>TestFlight</summary>
 
 You can easily upload new builds to TestFlight (which is part of App Store Connect) using _fastlane_. To do so, just use the built-in `testflight` action after building your app
@@ -102,7 +102,7 @@ With _fastlane_, you can also automatically manage your beta testers, check out 
 ---
 </details>
 
-<details>
+<details markdown="1">
 <summary>Firebase App Distribution</summary>
 
 Install the Firebase App Distribution plugin:
@@ -137,7 +137,7 @@ For more information and options (such as adding release notes) see the full [Ge
 ---
 </details>
 
-<details>
+<details markdown="1">
 <summary>HockeyApp</summary>
 
 ```ruby
@@ -158,7 +158,7 @@ fastlane action hockey
 
 </details>
 
-<details>
+<details markdown="1">
 <summary>TestFairy</summary>
 
 ```ruby
@@ -190,7 +190,7 @@ More information about additional supported beta testing services can be found i
 
 # Release Notes
 
-<details>
+<details markdown="1">
 <summary>Automatically based on git commits</summary>
 
 Your changelog changes, so it doesn't make a lot of sense to store a static release note in the `Fastfile`.
@@ -216,7 +216,7 @@ changelog_from_git_commits(
 ---
 </details>
 
-<details>
+<details markdown="1">
 <summary>Prompt for changelog</summary>
 
 You can automatically be asked for the changelog in your terminal using the `prompt` action:
@@ -243,7 +243,7 @@ end
 ---
 </details>
 
-<details>
+<details markdown="1">
 <summary>Fetching the changelog from the file system or remote server</summary>
 
 You can fetch values from anywhere in your `Fastfile`, including the file system and remote server
@@ -269,10 +269,10 @@ end
 
 ## Best Practices
 
-<details>
+<details markdown="1">
 <summary>Manage devices and testers using _fastlane_</summary>
 
-<details>
+<details markdown="1">
 <summary>TestFlight</summary>
 
 If you're using TestFlight you don't need to worry about UDIDs of your devices. Instead you just maintain a list of testers based on their Apple ID email address.
@@ -302,7 +302,7 @@ fastlane pilot add email@invite.com -a com.app.name
 
 </details>
 
-<details>
+<details markdown="1">
 <summary>Third party beta testing services</summary>
 
 If you're using a third party beta testing service, you'll need to manage your registered devices and their UDIDs. _fastlane_ already supports device registrations and updating provisioning profiles out of the box. 
@@ -330,7 +330,7 @@ B123456789012345678901234567890123456789  DeviceName2
 </details>
 </details>
 
-<details>
+<details markdown="1">
 <summary>Incrementing the build number</summary>
 
 Depending on the beta testing service you use, you'll have to increment the build number each time you upload a new build. This is a requirement for TestFlight for example.

--- a/docs/getting-started/ios/screenshots.md
+++ b/docs/getting-started/ios/screenshots.md
@@ -214,7 +214,7 @@ If you want to upload the screenshots to the App Store, you **have** to provide 
 
 ### Dependencies
 
-<details>
+<details markdown="1">
 <summary>Installing ImageMagick</summary>
 
 To perform image manipulation, _frameit_ depends on a tool called `imagemagick`. The easiest way to install it is through [homebrew](http://brew.sh/):
@@ -224,7 +224,7 @@ brew install libpng jpeg imagemagick
 ```
 </details>
 
-<details>
+<details markdown="1">
 <summary>Troubleshooting ImageMagick</summary>
 
 If you have installed _imagemagick_ but are seeing error messages like:
@@ -240,7 +240,7 @@ brew uninstall imagemagick; brew install libpng jpeg; brew install imagemagick -
 ```
 </details>
 
-<details>
+<details markdown="1">
 <summary>Setting Up Device Frames</summary>
 
 To download the latest device frames, you can run
@@ -271,7 +271,7 @@ fastlane action frame_screenshots
 
 ## Advanced _snapshot_
 
-<details>
+<details markdown="1">
 <summary>Sample uses</summary>
 
 ```ruby
@@ -325,7 +325,7 @@ fastlane action capture_screenshots
 ```
 </details>
 
-<details>
+<details markdown="1">
 <summary>Reset Xcode simulators</summary>
 
 You can run this command in the terminal to delete and re-create all iOS simulators. This is useful when Xcode duplicated your local simulators.
@@ -335,7 +335,7 @@ fastlane snapshot reset_simulators
 ```
 </details>
 
-<details>
+<details markdown="1">
 <summary>Launch Arguments</summary>
 
 You can provide additional arguments to your app on launch. These strings will be available in your app (eg. not in the testing target) through `ProcessInfo.processInfo.arguments`. Alternatively, use user-default syntax (`-key value`) and they will be available as key-value pairs in `UserDefaults.standard`.
@@ -370,7 +370,7 @@ launch_arguments([
 ```
 </details>
 
-<details>
+<details markdown="1">
 <summary>Update snapshot helpers</summary>
 
 Some updates require the helper files to be updated. _snapshot_ will automatically warn you and tell you how to update.
@@ -385,14 +385,14 @@ to update your `SnapshotHelper.swift` files. In case you modified your `Snapshot
 
 </details>
 
-<details>
+<details markdown="1">
 <summary>Clean status bar</summary>
 
 To clean the status bar (9:41, full battery and full signal), use [SimulatorStatusMagic](https://github.com/shinydevelopment/SimulatorStatusMagic).
 
 </details>
 
-<details>
+<details markdown="1">
 <summary>How does _snapshot_ work?</summary>
 
 The easiest solution would be to just render the UIWindow into a file. That's not possible because UI Tests don't run on a main thread. So _snapshot_ uses a different approach:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ google_analytics:
 strict: false
 markdown_extensions:
 - markdown.extensions.attr_list
+- markdown.extensions.md_in_html
 - markdown_include.include
 - mdx_truly_sane_lists
 - toc:


### PR DESCRIPTION
### Motivation and Context
Resolves #1074
Markdown is not parsed in foldable details html tag, e.g. on https://docs.fastlane.tools/actions/deliver/

### Description
Added  `markdown.extensions.md_in_html` extension to parse markdown in html tags.
Used `markdown="1"` to parse markdown.

Fix based on:
https://github.com/mkdocs/mkdocs/issues/1687
https://python-markdown.github.io/extensions/md_in_html/

### Testing Steps
Install mkdocs locally, build site, check html pages.
Dear reviewer, please check if the changes in formatting are fine.
