### PR TITLE
Remove old duplicate issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,4 +1,0 @@
-Issues submitted here should pertain to bugs/features of our [docs site](https://docs.fastlane.tools/).
-
-If you're looking to submit an issue (bug/question/feature) about _fastlane_ itself, please do so in the [main repo](https://github.com/fastlane/fastlane/issues). 
-


### PR DESCRIPTION
Removes unused ISSUE_TEMPLATE from repo root, long obsoleted and reworded since #452 by .github/* content.