### PR TITLE
Fix sidenavv.css 404 not found

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,7 +21,6 @@ markdown_extensions:
     toc_depth: 2
 docs_dir: docs
 extra_css:
-- "./css/sidenavv.css"
 - "./css/fastlane.css"
 - "./css/code.css"
 - "./css/breadcrumbs.css"


### PR DESCRIPTION
Removes missing/non-existent extra css:

> ![Screen Shot 2021-08-10 at 14 32 55](https://user-images.githubusercontent.com/1784648/128867449-bee6bf09-0f1a-4593-a1b5-32f39e9f96e2.png)

It was introduced with https://github.com/fastlane/docs/pull/1051/commits/d87a7c08d2dfb051df7b073d26629ee6790625c1 when migrating `mkdocs` in #1051 — seems like an error or some leftover from testing different cascade ordering to me.

I did my best to go through the whole PR branch (dope commit messages 👍) to trace it back to more context around the change, and can't find any other reasoning. No such file is in the source, nothing like that is being built to `gh-pages`, and all netlify builds since also display this 404 error. Which leads me to thinking this is a mere typo or omission, not a shim for testing or something undocumented, made on purpose that should've made it into prod.