### PR TITLE
add documentation for GitHub Actions under CI best practices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ site/
 /fastlane/report.xml
 .keys
 *.swp
+vendor/bundle

--- a/docs/best-practices/continuous-integration.md
+++ b/docs/best-practices/continuous-integration.md
@@ -19,6 +19,7 @@ Multiple CI products and services offer integrations with _fastlane_:
 - [Bitrise](/best-practices/continuous-integration/bitrise/)
 - [CircleCI](/best-practices/continuous-integration/circle-ci/)
 - [GitLab CI](/best-practices/continuous-integration/gitlab/)
+- [GitHub Actions](/best-practices/continuous-integration/github/)
 - [Jenkins](/best-practices/continuous-integration/jenkins/)
 - [NeverCode](/best-practices/continuous-integration/nevercode/)
 - [Semaphore](/best-practices/continuous-integration/semaphore/)

--- a/docs/best-practices/continuous-integration/github.md
+++ b/docs/best-practices/continuous-integration/github.md
@@ -1,0 +1,50 @@
+# GitHub Actions Integration
+
+Use [GitHub Actions runner](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners) running on a macOS machine
+to build using fastlane.
+
+## Repository setup
+
+First create a `Gemfile` in the root of your project with the following content:
+
+```ruby
+source 'https://rubygems.org'
+
+gem 'fastlane'
+```
+
+Add a `.github/workflows/build-ios-app.yml` file to trigger _fastlane_.
+
+```yml
+name: build-ios-app
+on:
+  push:
+    branches:
+      - 'master'
+jobs:
+  build:
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: fastlane beta
+        env:
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+```
+
+See [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions)
+for more information on how this file works.
+
+## Setting up the lanes
+
+```ruby
+platform :ios do
+  lane :beta do
+    setup_ci if ENV['CI']
+    match(type: 'appstore')
+    build_app
+    upload_to_testflight(skip_waiting_for_build_processing: true)
+  end
+end
+```
+
+`setup_ci` creates a temporary keychain. Without this, the build could freeze and never finish.

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -33,6 +33,6 @@ fastlane update_available_plugins
 
 ----
 
-This README.md is auto-generated and will be re-generated every time [fastlane](https://fastlane.tools) is run.
+This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.
 More information about fastlane can be found on [fastlane.tools](https://fastlane.tools).
 The documentation of fastlane can be found on [docs.fastlane.tools](https://docs.fastlane.tools).


### PR DESCRIPTION
<!--
Thanks for contributing to _fastlane_! Before you submit your pull request, note that files in the docs folder covering Actions (actions.md and actions/*) and Plugins (available-plugins.md) are auto-generated.
If this is the case, please modify the documentation at their sources (https://github.com/fastlane/fastlane or plugin repository) and will be updated here regularly.
-->

Hi, thank you for the great tool and the fantastic documentation.

I want to add a documentation for GitHub Actions. I have been stack until I found `setup_ci` from the following answer.

https://stackoverflow.com/questions/58118395/github-action-macos-keychain-access

Thanks


Edit: Resolves #928