### PR TITLE
remove "Edit on GitHub" button from available plugins page

### DIFF
--- a/theme/breadcrumbs.html
+++ b/theme/breadcrumbs.html
@@ -13,7 +13,7 @@
     {% if page %}<li>{{ page.title }}</li>{% endif %}
 
 
-    {% if page and page.file.src_path != "actions.md" and page.src_path != "plugins/available-plugins.md" %}
+    {% if page and page.file.src_path != "actions.md" and page.file.src_path != "plugins/available-plugins.md" %}
       <li class="wy-breadcrumbs-aside">
         {%- block repo %}
         {% if page and page.edit_url %}


### PR DESCRIPTION
<!--
Thanks for contributing to _fastlane_! Before you submit your pull request, note that files in the docs folder covering Actions (actions.md and actions/*) and Plugins (available-plugins.md) are auto-generated.
If this is the case, please modify the documentation at their sources (https://github.com/fastlane/fastlane or plugin repository) and will be updated here regularly.
-->
Remove "edit on github" button from top navigation on available plugins docs - fix