### PR TITLE
Remove "Edit on Github" button from documentation of actions

### DIFF
--- a/theme/breadcrumbs.html
+++ b/theme/breadcrumbs.html
@@ -13,7 +13,9 @@
     {% if page %}<li>{{ page.title }}</li>{% endif %}
 
 
-    {% if page and page.file.src_path != "actions.md" and not "actions/" in page.file.src_path and page.file.src_path != "plugins/available-plugins.md" %}
+    {% if page and page.file.src_path != "actions.md" 
+          and not "actions/" in page.file.src_path 
+          and page.file.src_path != "plugins/available-plugins.md" %}
       <li class="wy-breadcrumbs-aside">
         {%- block repo %}
         {% if page and page.edit_url %}

--- a/theme/breadcrumbs.html
+++ b/theme/breadcrumbs.html
@@ -13,7 +13,7 @@
     {% if page %}<li>{{ page.title }}</li>{% endif %}
 
 
-    {% if page and page.file.src_path != "actions.md" and page.file.src_path != "plugins/available-plugins.md" %}
+    {% if page and page.file.src_path != "actions.md" and not "actions/" in page.file.src_path and page.file.src_path != "plugins/available-plugins.md" %}
       <li class="wy-breadcrumbs-aside">
         {%- block repo %}
         {% if page and page.edit_url %}


### PR DESCRIPTION
<!--
Thanks for contributing to _fastlane_! Before you submit your pull request, note that files in the docs folder covering Actions (actions.md and actions/*) and Plugins (available-plugins.md) are auto-generated.
If this is the case, please modify the documentation at their sources (https://github.com/fastlane/fastlane or plugin repository) and will be updated here regularly.
-->
"Edit on Github" button should not be present on generated actions documentation pages.
Right now following the link gives 404 error.

Should `xbreadcrumbs.html` be changed in a similar way?