### PR TITLE
"Edit on Github" button for action details opens source file in fastlane repository

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ plugins:
       hooks:
         on_pre_build: "hooks:copy_generated_files"
 docs_dir: docs
+fastlane_repo_base_edit_uri: "https://github.com/fastlane/fastlane/edit/master/fastlane/lib/fastlane"
 extra_css:
 - "./css/sidenavv.css"
 - "./css/fastlane.css"

--- a/theme/breadcrumbs.html
+++ b/theme/breadcrumbs.html
@@ -13,7 +13,9 @@
     {% if page %}<li>{{ page.title }}</li>{% endif %}
 
 
-    {% if page and page.file.src_path != "actions.md" and not "actions/" in page.file.src_path and page.file.src_path != "plugins/available-plugins.md" %}
+    {% if page and page.file.src_path != "actions.md" 
+          and not "actions/" in page.file.src_path 
+          and page.file.src_path != "plugins/available-plugins.md" %}
       <li class="wy-breadcrumbs-aside">
         {%- block repo %}
         {% if page and page.edit_url %}

--- a/theme/breadcrumbs.html
+++ b/theme/breadcrumbs.html
@@ -12,22 +12,27 @@
     {% endif %}
     {% if page %}<li>{{ page.title }}</li>{% endif %}
 
-
-    {% if page and page.file.src_path != "actions.md" 
-          and not "actions/" in page.file.src_path 
-          and page.file.src_path != "plugins/available-plugins.md" %}
+    {% if page and page.file.src_path != "actions.md" and page.file.src_path != "plugins/available-plugins.md" %}
       <li class="wy-breadcrumbs-aside">
         {%- block repo %}
-        {% if page and page.edit_url %}
-          <a href="{{ page.edit_url }}"
+
+        {% set icon_class_block %}
           {%- if config.repo_name|lower == 'github' %}
             class="icon icon-github"
           {%- elif config.repo_name|lower == 'bitbucket' %}
             class="icon icon-bitbucket"
           {%- elif config.repo_name|lower == 'gitlab' %}
             class="icon icon-gitlab"
-          {% endif %}> Edit on {{ config.repo_name }}</a>
+          {% endif %}
+        {% endset %}
+
+        {% if "actions/" in page.file.src_path %}
+          <a href="{{ config.fastlane_repo_base_edit_uri }}/{{ page.file.src_path|string|safe|replace(".md", ".rb") }}" {{ icon_class_block }}>
+        {% elif page.edit_url %}
+          <a href="{{ page.edit_url }}" {{ icon_class_block }}>
         {% endif %}
+        Edit on {{ config.repo_name }}</a>
+
         {%- endblock %}
       </li>
     {% endif %}

--- a/theme/breadcrumbs.html
+++ b/theme/breadcrumbs.html
@@ -13,7 +13,7 @@
     {% if page %}<li>{{ page.title }}</li>{% endif %}
 
 
-    {% if page and page.file.src_path != "actions.md" and page.file.src_path != "plugins/available-plugins.md" %}
+    {% if page and page.file.src_path != "actions.md" and not "actions/" in page.file.src_path and page.file.src_path != "plugins/available-plugins.md" %}
       <li class="wy-breadcrumbs-aside">
         {%- block repo %}
         {% if page and page.edit_url %}

--- a/theme/breadcrumbs.html
+++ b/theme/breadcrumbs.html
@@ -26,12 +26,15 @@
           {% endif %}
         {% endset %}
 
-        {% if "actions/" in page.file.src_path %}
-          <a href="{{ config.fastlane_repo_base_edit_uri }}/{{ page.file.src_path|string|safe|replace(".md", ".rb") }}" {{ icon_class_block }}>
-        {% elif page.edit_url %}
-          <a href="{{ page.edit_url }}" {{ icon_class_block }}>
-        {% endif %}
-        Edit on {{ config.repo_name }}</a>
+        {% set edit_docs_file_url %}
+          {%- if "actions/" in page.file.src_path %}
+            {{ config.fastlane_repo_base_edit_uri }}/{{ page.file.src_path|string|safe|replace(".md", ".rb") }}
+          {%- elif page.edit_url %}
+            {{ page.edit_url }}
+          {%- endif %}
+        {% endset %}
+
+        <a href="{{ edit_docs_file_url }}" {{ icon_class_block }}>Edit on {{ config.repo_name }}</a>
 
         {%- endblock %}
       </li>


### PR DESCRIPTION
"Edit on Github" button for action details is restored.
Links for source `.rb` files are created based on
- `fastlane_repo_base_edit_uri` from `mkdocs.yml` and 
- `page.file.src_path` with changed extension from `.md` to .rb`