### PR TITLE
Update mkdocs copyright from 2021 to 2022

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_name: fastlane docs
 site_author: fastlane team
 site_description: Documentation for fastlane tools, the easiest way to automate building
   and releasing your iOS and Android apps
-copyright: Copyright &copy; 2021 <a href="https://fastlane.tools">fastlane</a>
+copyright: Copyright &copy; 2022 <a href="https://fastlane.tools">fastlane</a>
 repo_url: https://github.com/fastlane/docs
 theme:
   name: readthedocs


### PR DESCRIPTION
<!--
Thanks for contributing to _fastlane_! Before you submit your pull request, note that files in the `/docs/generated` folder are auto-generated.
If this is the case, please modify the documentation at its source (at https://github.com/fastlane/fastlane or plugin repository) and it will propagate here on regular basis.
-->

The copyright date displayed in the documentation has been updated.
