### PR TITLE
Document new FASTLANE_HIDE_PLUGINS_TABLE env var

### DIFF
--- a/docs/advanced/fastlane.md
+++ b/docs/advanced/fastlane.md
@@ -18,6 +18,7 @@ You can set the environment variable `FASTLANE_HIDE_CHANGELOG` to hide the detai
 - To output the timezone in the timestamp, set the `FASTLANE_SHOW_TIMEZONE` environment variable to true.
 - To disable output formatting, set the `FASTLANE_DISABLE_OUTPUT_FORMAT` environment variable to true.
 - To disable warnings about startup time and Gemfile usage, set the `SKIP_SLOW_FASTLANE_WARNING` environment variable to true.
+- To disable the plugins summary table printed at the beginning, set the `FASTLANE_HIDE_PLUGINS_TABLE` environment variable to true.
 - To disable action summary table output, set the `FASTLANE_SKIP_ACTION_SUMMARY` environment variable to true.
 
 ## How fastlane works


### PR DESCRIPTION
This new environment variable was introduced in https://github.com/fastlane/fastlane/pull/19963 (h/t @rogerluan) and shipped in [fastlane 2.205.0](https://github.com/fastlane/fastlane/releases/tag/2.205.0)

