### PR TITLE
docs(ci): update macos runner name

### DIFF
--- a/docs/best-practices/continuous-integration/github.md
+++ b/docs/best-practices/continuous-integration/github.md
@@ -22,7 +22,7 @@ on:
       - 'master'
 jobs:
   build:
-    runs-on: macOS-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
       - run: fastlane beta


### PR DESCRIPTION
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners

Seems not to be a generated doc from what I checked 🤞 