### PR TITLE
Refer to built-in status bar modification method

### DIFF
--- a/docs/getting-started/ios/screenshots.md
+++ b/docs/getting-started/ios/screenshots.md
@@ -388,7 +388,7 @@ to update your `SnapshotHelper.swift` files. In case you modified your `Snapshot
 <details markdown="1">
 <summary>Clean status bar</summary>
 
-To clean the status bar (9:41, full battery and full signal), use [SimulatorStatusMagic](https://github.com/shinydevelopment/SimulatorStatusMagic).
+To clean the status bar (9:41, full battery and full signal), use [the `override_status_bar` parameter](https://docs.fastlane.tools/actions/capture_ios_screenshots/#use-a-clean-status-bar).
 
 </details>
 


### PR DESCRIPTION
`override_status_bar` is built in, and uses a first-party supported method for overriding the status bar, so the docs should probably mention that. If we want to refer to SimulatorStatusMagic for more advanced overrides, I suppose we could, although I'm not sure if it's supported any more.