### PR TITLE
Add a "Fully automatic" workflow

### DIFF
--- a/docs/codesigning/getting-started.md
+++ b/docs/codesigning/getting-started.md
@@ -53,6 +53,19 @@ That's why it is recommended to specify a specific provisioning profile somehow:
 
 The instructions below are more advanced, and take more time to setup than other approaches.
 
+##### Fully Automatic Signing
+
+If you want to keep your default Xcode workflow and be able to archive/upload builds from Xcode without fastlane if needed, you can simply use a lane like this:
+
+```ruby
+lane :release do
+  build_app(scheme: "Release")
+  upload_to_testflight
+end
+```
+
+Replace "Release" with the name of the scheme you currently use to archive/upload builds. Just make sure it is shared (in Xcode, click on the current scheme and scroll to "Manage Schemes…" at the bottom).
+
 ##### Automatic & Manual Signing
 
 To simplify development workflow you could use `Automatic` code signing for development, and `Manual` for release builds.


### PR DESCRIPTION
This follows a discussion with @joshdholtz on Twitter.

I wanted to make sure I would still be able to upload builds from Xcode if fastlane stopped working for some reason.
But after reading the docs, my setup asked me for the git repo with the certificates, which startled me.
Also, I hit another roadblock because my release scheme wasn't shared.