### PR TITLE
Add example of using a hash in App Store Connect API key docs

### DIFF
--- a/docs/app-store-connect-api.md
+++ b/docs/app-store-connect-api.md
@@ -92,6 +92,19 @@ end
 Keys and values that can be used in hash in `api_key` parameter in actions (e.g. `upload_to_testflight`) and tools (e.g. `cert`) are described in _fastlane_ API Key JSON file format below.
 The only difference when using hash is that you could use `filepath` instead of `key`.
 
+Below is an example of API key being used with CLI:
+
+```no-highlight
+$ bundle exec fastlane match appstore \
+    --api_key "
+        {
+            \"filepath\": \"/Users/bartek/Downloads/AuthKey_TJP2GMDZCI.p8\",
+            \"key_id\": \"TJP2GMDZCI\",
+            \"issuer_id\": \"57246542-96fe-1a63-e053-0824d011072a\"
+        }
+    "
+```
+
 Please note that `key_content` and `key_filepath` described in `app_store_connect_api_key` action are invalid both in hash and in JSON file.
 View [Token code on Github](https://github.com/fastlane/fastlane/blob/master/spaceship/lib/spaceship/connect_api/token.rb)
 


### PR DESCRIPTION
I think that section was lacking an example. It took me some time to Google the right syntax.