### PR TITLE
Update match manual decryption example

### DIFF
--- a/docs/generated/actions/match.md
+++ b/docs/generated/actions/match.md
@@ -528,6 +528,8 @@ If you want to manually decrypt a file you can.
 openssl aes-256-cbc -k "<password>" -in "<fileYouWantToDecryptPath>" -out "<decryptedFilePath>" -a -d -md [md5|sha256]
 ```
 
+_**Note:** You may need to swap double quotes `"` for single quotes `'` if your match password contains an exclamation mark `!`_
+
 #### Export Distribution Certificate and Private Key as Single .p12 File
 
 _match_ stores the certificate (`.cer`) and the private key (`.p12`) files separately. The following steps will repackage the separate certificate and private key into a single `.p12` file.

--- a/docs/generated/actions/match.md
+++ b/docs/generated/actions/match.md
@@ -525,7 +525,7 @@ Please be careful when using this option and ensure the certificates and profile
 If you want to manually decrypt a file you can.
 
 ```no-highlight
-openssl aes-256-cbc -k "<password>" -in "<fileYouWantToDecryptPath>" -out "<decryptedFilePath>" -a -d
+openssl aes-256-cbc -k "<password>" -in "<fileYouWantToDecryptPath>" -out "<decryptedFilePath>" -a -d -md [md5|sha256]
 ```
 
 #### Export Distribution Certificate and Private Key as Single .p12 File

--- a/docs/generated/actions/match.md
+++ b/docs/generated/actions/match.md
@@ -528,7 +528,7 @@ If you want to manually decrypt a file you can.
 openssl aes-256-cbc -k "<password>" -in "<fileYouWantToDecryptPath>" -out "<decryptedFilePath>" -a -d -md [md5|sha256]
 ```
 
-_**Note:** You may need to swap double quotes `"` for single quotes `'` if your match password contains an exclamation mark `!`_
+_**Note:** You may need to swap double quotes `"` for single quotes `'` if your match password contains an exclamation mark `!`._
 
 #### Export Distribution Certificate and Private Key as Single .p12 File
 


### PR DESCRIPTION
When attempting to manually decrypt some provisioning profiles generated by match, I noticed that the existing manual decryption example was generating a `bad decrypt` error:
```Shell
tylermilner@Tylers-MBP adhoc % openssl aes-256-cbc -k 'password' -in 'AdHoc_com.tylermilner.appname.mobileprovision' -out 'AdHoc_com.tylermilner.appname.decrypted.mobileprovision' -a -d       
bad decrypt
8547113792:error:06FFF064:digital envelope routines:CRYPTO_internal:bad decrypt:/AppleInternal/Library/BuildRoots/97f6331a-ba75-11ed-a4bc-863efbbaf80d/Library/Caches/com.apple.xbs/Sources/libressl/libressl-3.3/crypto/evp/evp_enc.c:554:
```

Based on the code samples for `.cer` + `.p12` repackaging, I noticed that they have the `-md` flag specified at the end. Adding this flag with the appropriate hash type results in a successful decryption:
```Shell
tylermilner@Tylers-MBP adhoc % openssl aes-256-cbc -k 'password' -in 'AdHoc_com.tylermilner.appname.mobileprovision' -out 'AdHoc_com.tylermilner.appname.decrypted.mobileprovision' -a -d -md md5
```

Also in my case, my match repo password contains an exclamation point `!`, which was causing `dquote>` to be output with no actual decryption happening when run:
```Shell
tylermilner@Tylers-MBP adhoc % openssl aes-256-cbc -k "password!" -in "AdHoc_com.tylermilner.appname.mobileprovision" -out "AdHoc_com.tylermilner.appname.decrypted.mobileprovision" -a -d -md md5
dquote> 
```

It appears that the `!` was causing the trailing quote for the password parameter to get removed when run, which I could verify by pressing up arrow `↑` to stage the previous command in Terminal (notice missing double quote `"` after password):
```Shell
openssl aes-256-cbc -k "password! -in "AdHoc_com.tylermilner.appname.mobileprovision" -out "AdHoc_com.tylermilner.appname.decrypted.mobileprovision" -a -d -md md5
```

Switching from double quotes to single quotes as suggested in [this SO post](https://stackoverflow.com/a/65930574/4343618), allowed my command to succeed with the `!` in the password. I added a note here in the docs to make others aware as well.