### PR TITLE
fix typos in "best practices" pages

### DIFF
--- a/docs/best-practices/continuous-integration/bamboo.md
+++ b/docs/best-practices/continuous-integration/bamboo.md
@@ -25,7 +25,7 @@ By default bamboo will do an anonymous shallow clone of the repo.  This will not
 ```ruby
 # In prep for eventually committing a version/build bump - set the git params
 sh('git config user.name "<COMMITTER USERNAME>"')
-sh('git config user.email <COMITTER EMAIL>')
+sh('git config user.email <COMMITTER EMAIL>')
 
 # Bamboo does an anonymous checkout so in order to update the build versions must set the git repo URL
 git_remote_cmd = 'git remote set-url origin ' + ENV['bamboo_repository_git_repositoryUrl']

--- a/docs/best-practices/continuous-integration/codemagic.md
+++ b/docs/best-practices/continuous-integration/codemagic.md
@@ -10,9 +10,9 @@ For publishing iOS apps, it is recommended to create an App Store Connect API ke
 
 The following **environment variables** need to be added to your workflow for *fastlane* integration. 
 
-- `MATCH_PASSWORD` - the password used to encrypt/decrypt the repository used to store your distrbution certificates and provisioning profiles.
+- `MATCH_PASSWORD` - the password used to encrypt/decrypt the repository used to store your distribution certificates and provisioning profiles.
 - `MATCH_KEYCHAIN` - an arbitrary name to use for the keychain on the Codemagic build server, e.g "fastlane_keychain"
-- `MATCH_SSH_KEY` - an SSH private key used for cloning the Match repository that contains your distrbution certificates and provisioning profiles. The public key should be added to your Github account. See [here](https://docs.codemagic.io/configuration/access-private-git-submodules/) for more information about accessing Git dependencies with SSH keys.
+- `MATCH_SSH_KEY` - an SSH private key used for cloning the Match repository that contains your distribution certificates and provisioning profiles. The public key should be added to your Github account. See [here](https://docs.codemagic.io/configuration/access-private-git-submodules/) for more information about accessing Git dependencies with SSH keys.
 - `APP_STORE_CONNECT_PRIVATE_KEY` - the App Store Connect API key. Copy the entire contents of the .p8 file and paste into the environment variable value field.
 - `APP_STORE_CONNECT_KEY_IDENTIFIER` - the key identifier of your App Store Connect API key.
 - `APP_STORE_CONNECT_ISSUER_ID` - the issuer of your App Store Connect API key.

--- a/docs/best-practices/xcodebuild-formatters.md
+++ b/docs/best-practices/xcodebuild-formatters.md
@@ -26,7 +26,7 @@ scan(
   xcodebuild_formatter: "xcpretty"
 )
 
-# Specificy a local install of xcbeautify
+# Specifify a local install of xcbeautify
 scan(
   xcodebuild_formatter: "/custom/path/to/xcbeautify"
 )

--- a/docs/best-practices/xcodebuild-formatters.md
+++ b/docs/best-practices/xcodebuild-formatters.md
@@ -26,7 +26,7 @@ scan(
   xcodebuild_formatter: "xcpretty"
 )
 
-# Specifify a local install of xcbeautify
+# Specify a local installation of xcbeautify
 scan(
   xcodebuild_formatter: "/custom/path/to/xcbeautify"
 )


### PR DESCRIPTION
<!--
Thanks for contributing to _fastlane_! Before you submit your pull request, note that files in the `/docs/generated` folder are auto-generated.
If this is the case, please modify the documentation at its source (at https://github.com/fastlane/fastlane or plugin repository) and it will propagate here on regular basis.
-->
This PR fix the typo that has been seen in various files.

```pseudo
distrbution > distribution
practies > practise
managment > management
unque > unique
configuraiton > configuration
```