### PR TITLE
Update bundler to a version that will not cause issues when building on ruby 2.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,6 +276,8 @@ GEM
 
 PLATFORMS
   ruby
+  -darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   danger (~> 8)
@@ -284,4 +286,4 @@ DEPENDENCIES
   xcov
 
 BUNDLED WITH
-   2.3.11
+   2.3.21


### PR DESCRIPTION

<!--
Thanks for contributing to _fastlane_! Before you submit your pull request, note that files in the `/docs/generated` folder are auto-generated.
If this is the case, please modify the documentation at its source (at https://github.com/fastlane/fastlane or plugin repository) and it will propagate here on regular basis.
-->
