### PR TITLE
Add build date to footer

### DIFF
--- a/theme/footer.html
+++ b/theme/footer.html
@@ -22,7 +22,7 @@
     </p>
   </div>
 
-  Built with <a href="http://www.mkdocs.org">MkDocs</a> using a <a href="https://github.com/readthedocs/sphinx_rtd_theme">theme</a> provided by <a href="https://readthedocs.org">Read the Docs</a> - Copyright &copy; {{ build_date_utc.strftime('%Y') }} <a href="https://fastlane.tools">fastlane</a>
+  Documentation built {{ build_date_utc.strftime('%Y-%m-%d') }} with <a href="http://www.mkdocs.org">MkDocs</a> <!-- using <a href="https://www.mkdocs.org/user-guide/choosing-your-theme/#readthedocs">readthedocs theme</a> --> — Copyright &copy; {{ build_date_utc.strftime('%Y') }} <a href="https://fastlane.tools">fastlane</a>
 </footer>
 
 <script type="text/javascript">


### PR DESCRIPTION
Adds `Y-m-d` last build date to footer (while removing some default bits that are more confusing than not /e.g. the sphinx template reference/…) to give an idea when master was last deployed to production.

![Screen Shot 2024-03-17 at 17 34 05](https://github.com/fastlane/docs/assets/1784648/47423bc1-4eba-4cfa-86d3-a38cb962a770)

(proposed compared to current)
