### PR TITLE
Bump bundler to final release of v2.4.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -291,4 +291,4 @@ DEPENDENCIES
   xcov
 
 BUNDLED WITH
-   2.3.21
+   2.4.22


### PR DESCRIPTION
before:

![Screenshot 2024-06-09 at 18 50 20](https://github.com/fastlane/docs/assets/1784648/e3d8bd52-de02-4d99-86d6-df2b0eec3da2)


_(takes ~55mins to resolve)_

after:

![Screenshot 2024-06-09 at 18 34 54](https://github.com/fastlane/docs/assets/1784648/cd484d81-b477-4ea0-8bbf-cf65aece7943)

_(done under ~1min)_

This is the latest v2.4.x release available from several months ago — I have neither tested nor researched the compatibility and requirements for the v2.5.x versions that are being released currently, but this seems to work well for now.