### PR TITLE
Fix broken link and add more detailed instructions in the App Store Connect API page

### DIFF
--- a/docs/app-store-connect-api.md
+++ b/docs/app-store-connect-api.md
@@ -36,7 +36,7 @@ Below are the statuses of each tool:
 
 1. Create a new App Store Connect API Key in the [Users page](https://appstoreconnect.apple.com/access/api)
   - For more info, go to the [App Store Connect API Docs](https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api)
-  - Select the "Keys" tab
+  - Open the ‘Integrations’ tab, select ‘App Store Connect API,’ and create a new TEAM API using the ‘+’ button. 
   - Give your API Key an appropriate role for the task at hand. You can read more about roles in [Permissions in App Store Connect](https://developer.apple.com/support/roles/)
   - Note the Issuer ID as you will need it for the configuration steps below
 2. Download the newly created API Key file (`.p8`)

--- a/docs/app-store-connect-api.md
+++ b/docs/app-store-connect-api.md
@@ -34,9 +34,10 @@ Below are the statuses of each tool:
 
 ## Creating an App Store Connect API Key
 
-1. Create a new App Store Connect API Key in the [Users page](https://appstoreconnect.apple.com/access/api)
+1. Create a new App Store Connect API Key in the [Users and Access](https://appstoreconnect.apple.com/access/users) page
   - For more info, go to the [App Store Connect API Docs](https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api)
-  - Open the ‘Integrations’ tab, select ‘App Store Connect API,’ and create a new TEAM API using the ‘+’ button. 
+  - Open the `Integrations` tab, select `App Store Connect API`, and create a new "Team Key" using the `+` button
+    - Note that if you can't see the `App Store Connect API` tab, this means you don't have permission yet. Please refer to the docs above to know how to get this permission
   - Give your API Key an appropriate role for the task at hand. You can read more about roles in [Permissions in App Store Connect](https://developer.apple.com/support/roles/)
   - Note the Issuer ID as you will need it for the configuration steps below
 2. Download the newly created API Key file (`.p8`)


### PR DESCRIPTION
They renamed Keys to Integration, which miss lead me for a while, until I realize that the documentation is pointing me in the wrong direction.

<!--
Thanks for contributing to _fastlane_! Before you submit your pull request, note that files in the `/docs/generated` folder are auto-generated.
If this is the case, please modify the documentation at its source (at https://github.com/fastlane/fastlane or plugin repository) and it will propagate here on regular basis.
-->
