### PR TITLE
Restore GA tracking

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,8 @@ repo_url: https://github.com/fastlane/docs
 theme:
   name: readthedocs
   custom_dir: theme
+  analytics:
+    gtag: UA-18658848-13
 strict: false
 markdown_extensions:
 - markdown.extensions.attr_list

--- a/theme/base.html
+++ b/theme/base.html
@@ -56,14 +56,14 @@
   {%- block extrahead %} {% endblock %}
 
   {%- block analytics %}
-  {% if config.google_analytics %}
+  {% if config.theme.analytics %}
   <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-      ga('create', '{{ config.google_analytics[0] }}', '{{ config.google_analytics[1] }}');
+      ga('create', '{{ config.theme.analytics.gtag }}', 'auto');
       ga('send', 'pageview');
   </script>
   {% endif %}


### PR DESCRIPTION
GA4 integration should continue gathering data for (auto)migrated GA3/UA properties.

Resolves #1253