### PR TITLE
Remove obsolete troubleshooting section from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,3 @@ pipenv shell
 ## Adding a Python dependency
 
 Likely, to add a [Markdown extension](https://pythonhosted.org/Markdown/extensions/), install it with `pipenv install <some extension>` after making sure the virtualenv is loaded (`pipenv shell`).
-
-## Troubleshooting local docs server
-
-Running a local server with `mkdocs serve`, it may take several minutes to start. This delay is because `mkdocs` needs some time to read the `available-plugins.md` file. It can be confirmed by running `mkdocs serve --verbose` as `mkdocs` is stuck at reading this file.
-
-For testing changes on pages other than the list of available plugins, it is convenient to edit `docs/generated/available-plugins.md`, removing all of its content and saving the file before running `mkdocs serve`.


### PR DESCRIPTION
<!--
Thanks for contributing to _fastlane_! Before you submit your pull request, note that files in the `/docs/generated` folder are auto-generated.
If this is the case, please modify the documentation at its source (at https://github.com/fastlane/fastlane or plugin repository) and it will propagate here on regular basis.
-->

Removed the troubleshooting section from the README added in #1154 due to the performance improvements gained from updating the `mkdocs` dependency in #1213 (see the second quote reply from https://github.com/fastlane/docs/pull/1213#issuecomment-2195085675).