### PR TITLE
fix: add base netlify.toml to force into python build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[build]
+command = "mkdocs build"
+publish = "site/"
+environment = { PYTHON_VERSION = "3.8.13" }


### PR DESCRIPTION
Builds have been broken for previews for a few months. This occurred because Netlify automatic detection based on the `Gemfile` and `Pipfile` shifted from automatically detecting as a Python project + Ruby, to vice versa.

@joshdholtz probably has the configuration stored away in Netlify, but we can workaround this by introducing a [toml configuration file](https://docs.netlify.com/build/configure-builds/file-based-configuration/) which amazingly overrides the values in the interface.

> Be aware that if you have conflicting configuration values, settings specified in `netlify.toml` override any corresponding settings in the Netlify UI.

So we force the build by including a `PYTHON_VERSION` string to treat it as a Python build first