### PR TITLE
build: set gem location as vendor/bundle

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_PATH: "vendor/bundle"


### PR DESCRIPTION
The gitignore file already has `vendor/bundle` ignored - a common location to install gems.

Without a sane default set - folks like me who are trying to learn all the pipelines cannot effectively run them. Take this example of running `bundle exec fastlane update_docs` on main fastlane repo.

Ultimately after fastlane clones a new docs repo it executes this.

```ruby
Bundler.with_clean_env do
  sh("bundle update")
end
```

Which of course fails because the default gem location for this system at least is not in a user-land area - its system.

```
Errno::EACCES: Permission denied @ dir_s_mkdir - /var/lib/gems/3.3.0/cache
```

I'm under strong belief projects should declare where gems should be stored so alignment between local usage, CI usage and command usage can all depend on a specific setup. A simple `bundle update` hard-coded requires the end user to preconfigure environment variables or more - when the project should decide that.