### PR TITLE
Fix WWDC session link for code signing

### DIFF
--- a/docs/codesigning/getting-started.md
+++ b/docs/codesigning/getting-started.md
@@ -6,7 +6,7 @@ If you are just starting a new project, it's important to think about how you wa
 
 For existing projects it might make sense to switch from a manual process to the [match approach](https://codesigning.guide) to make it easier for new team-members to onboard.
 
-If you are new to code signing, check out the [WWDC session](https://developer.apple.com/videos/play/wwdc2016/401/) that describes the fundamentals of code signing in Xcode.
+If you are new to code signing, check out the [WWDC session](https://developer.apple.com/videos/play/wwdc2021/10204/) that describes modern app distribution, automatic signing, and cloud-managed certificates in Xcode.
 
 - [Using match](#using-match)
 - [Using cert and sigh](#using-cert-and-sigh)


### PR DESCRIPTION
Updated WWDC session link for code signing fundamentals.

Since Apple removed the video, we should provide a new link which somehow explains the same thing. 

Sadly, I couldn't find any straightforward guide from Apple which actually explains the same thing as the old video does. The closest video I could find is the provided link in the commit, which also explains modern signing somewhat.

Also, we can still see the session in the Wayback Machine right here, but I don't think we should provide a link to the Wayback Machine in the documentation.
https://web.archive.org/web/20170919213849/https://developer.apple.com/videos/play/wwdc2016/401/
