### PR TITLE
fix: support python3 or python during hooks.py call

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -4,7 +4,8 @@ opt_out_usage
 lane :test do |options|
   Dir.chdir("..") do
     if options[:skip_building]
-      sh("python hooks.py")
+      python = system("which python3 > /dev/null 2>&1") ? "python3" : "python"
+      sh("#{python} hooks.py")
     else
       build_site
     end


### PR DESCRIPTION
fixes: #1325 

I don't have `python` and don't want to set up an alias. This is pretty standard for Python 3 now.

```
➜  docs git:(move-to-uv) ✗ which python3 > /dev/null 2>&1
➜  docs git:(move-to-uv) ✗ echo $?
0
➜  docs git:(move-to-uv) ✗ which python > /dev/null 2>&1 
➜  docs git:(move-to-uv) ✗ echo $?
1
```

Testing

bundle exec fastlane test skip_building:true
```
[06:15:05]: ------------------------------
[06:15:05]: --- Step: python3 hooks.py ---
[06:15:05]: ------------------------------
[06:15:05]: $ python3 hooks.py
```