### PR TITLE
fix: correct js loading

### DIFF
--- a/docs/css/fabric.css
+++ b/docs/css/fabric.css
@@ -445,14 +445,6 @@ textarea,
   clear: both
 }
 
-@font-face {
-  font-family: 'FontAwesome';
-  src: url(../fonts/fontawesome-webfont.eot?v=4.2.0);
-  src: url(../fonts/fontawesome-webfont.eot?#iefix&v=4.2.0) format("embedded-opentype"),url(../fonts/fontawesome-webfont.woff?v=4.2.0) format("woff"),url(../fonts/fontawesome-webfont.ttf?v=4.2.0) format("truetype"),url(../fonts/fontawesome-webfont.svg?v=4.2.0#fontawesomeregular) format("svg");
-  font-weight: 400;
-  font-style: normal
-}
-
 .fa,
 .wy-menu-vertical li span.toctree-expand,
 .wy-menu-vertical li.on a span.toctree-expand,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,7 @@ extra_css:
 - "./css/breadcrumbs.css"
 - "./css/fabric.css"
 - "./css/sidenav.css"
+- "https://maxcdn.bootstrapcdn.com/font-awesome/4.6.1/css/font-awesome.min.css"
 nav:
 - Home: index.md
 - Getting Started:

--- a/theme/base.html
+++ b/theme/base.html
@@ -42,8 +42,8 @@
     var mkdocs_page_url = {{ page.abs_url|tojson|safe }};
   </script>
   {% endif %}
-  <script src="{{ 'js/jquery-2.1.1.min.js'|url }}" defer></script>
-  <script src="{{ 'js/modernizr-2.8.3.min.js'|url }}" defer></script>
+  <script src="{{ 'js/jquery-3.6.0.min.js'|url }}" defer></script>
+  <script src="{{ 'js/html5shiv.min.js'|url }}" defer></script>
   {%- if config.theme.highlightjs %}
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.5.0/highlight.min.js" integrity="sha384-0H+01+wORQpYAMaLWyObzDlXZaG1Mgzrj0DsIDeQX762Cfo2fPEycKxVmhlDjSV4" crossorigin="anonymous"></script>
   {%- for lang in config.theme.hljs_languages %}


### PR DESCRIPTION
## Problem

<img width="1403" height="847" alt="Screenshot 2026-05-03 at 11 33 42 AM" src="https://github.com/user-attachments/assets/74403858-ae1b-4b7d-833d-d7fd80d60685" />

Production docs for years have had a bunch of jQuery issues and such. I don't know exactly when this broke, but I went back like 2 years and it was still broken. Can't pinpoint exactly.

What I believe is issue is we have a custom theme on top of the default `readthedocs` theme. That theme injects things like jQuery and Modernizer for its theme. Over time we copied that import into our theme, but then updated the base theme. This meant things upgraded and/or changed.

## Solution
1. Remove all the included Font Awesomes as we don't have the fonts themselves in repo. Unaware of legal to include those, I defer to a CDN for them.
2. Move from jQuery 2 -> 3.
3. Move from Modernizer to HTML5Shiv


https://github.com/user-attachments/assets/10078f66-2dab-41e6-8d26-01d43b38a8b6

works :)