### PR TITLE
build: move to danger 9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source("https://rubygems.org")
 
-gem "danger", "~> 8" # Fixed on 8.x because 9.x uses Octokit 5.x which doesn't support Ruby 2.6, which is needed to run verify_docs lane in fastlane's main repo.
+gem "danger"
 gem "fastlane", git: "https://github.com/fastlane/fastlane"
 gem "rubocop"
 gem "rubocop-performance"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,19 @@ GEM
   specs:
     CFPropertyList (3.0.8)
     abbrev (0.1.2)
+    activesupport (8.1.3)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      json
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     artifactory (3.0.17)
@@ -95,27 +108,31 @@ GEM
     colored2 (3.1.2)
     commander (4.6.0)
       highline (~> 2.0.0)
+    concurrent-ruby (1.3.6)
+    connection_pool (3.0.2)
     cork (0.3.0)
       colored2 (~> 3.1)
     csv (3.3.5)
-    danger (8.6.1)
+    danger (9.5.3)
+      base64 (~> 0.2)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
-      colored2 (~> 3.1)
+      colored2 (>= 3.1, < 5)
       cork (~> 0.1)
-      faraday (>= 0.9.0, < 2.0)
+      faraday (>= 0.9.0, < 3.0)
       faraday-http-cache (~> 2.0)
-      git (~> 1.7)
-      kramdown (~> 2.3)
+      git (>= 1.13, < 3.0)
+      kramdown (>= 2.5.1, < 3.0)
       kramdown-parser-gfm (~> 1.0)
-      no_proxy_fix
-      octokit (~> 4.7)
-      terminal-table (>= 1, < 4)
+      octokit (>= 4.0)
+      pstore (~> 0.1)
+      terminal-table (>= 1, < 5)
     declarative (0.0.20)
     digest-crc (0.7.0)
       rake (>= 12.0.0, < 14.0.0)
     domain_name (0.6.20240107)
     dotenv (2.8.1)
+    drb (2.2.3)
     emoji_regex (3.2.3)
     excon (0.112.0)
     faraday (1.10.5)
@@ -136,7 +153,7 @@ GEM
     faraday-em_http (1.0.0)
     faraday-em_synchrony (1.0.1)
     faraday-excon (1.1.0)
-    faraday-http-cache (2.6.1)
+    faraday-http-cache (2.7.0)
       faraday (>= 0.8)
     faraday-httpclient (1.0.1)
     faraday-multipart (1.2.0)
@@ -151,8 +168,10 @@ GEM
     fastimage (2.4.1)
     fastlane-sirp (1.1.0)
     gh_inspector (1.1.3)
-    git (1.19.1)
+    git (2.3.3)
+      activesupport (>= 5.0)
       addressable (~> 2.8)
+      process_executer (~> 1.1)
       rchardet (~> 1.8)
     google-apis-androidpublisher_v3 (0.98.0)
       google-apis-core (>= 0.15.0, < 2.a)
@@ -197,6 +216,8 @@ GEM
       domain_name (~> 0.5)
     httpclient (2.9.0)
       mutex_m
+    i18n (1.14.8)
+      concurrent-ruby (~> 1.0)
     jmespath (1.6.2)
     json (2.19.2)
     jwt (2.10.2)
@@ -210,6 +231,9 @@ GEM
     logger (1.7.0)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
     multi_json (1.19.1)
     multipart-post (2.4.1)
     mutex_m (0.3.0)
@@ -217,8 +241,7 @@ GEM
     nap (1.1.0)
     naturally (2.3.0)
     nkf (0.2.0)
-    no_proxy_fix (0.1.2)
-    octokit (4.25.1)
+    octokit (10.0.0)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     open4 (1.3.4)
@@ -231,6 +254,8 @@ GEM
       racc
     plist (3.7.2)
     prism (1.9.0)
+    process_executer (1.3.0)
+    pstore (0.2.1)
     public_suffix (7.0.5)
     racc (1.8.1)
     rainbow (3.1.1)
@@ -268,6 +293,7 @@ GEM
     sawyer (0.9.3)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
+    securerandom (0.4.1)
     security (0.1.5)
     signet (0.21.0)
       addressable (~> 2.8)
@@ -286,8 +312,11 @@ GEM
     tty-screen (0.8.2)
     tty-spinner (0.9.3)
       tty-cursor (~> 0.7)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
     uber (0.1.0)
     unicode-display_width (2.6.0)
+    uri (1.1.1)
     word_wrap (1.0.0)
     xcodeproj (1.27.0)
       CFPropertyList (>= 2.3.3, < 4.0)
@@ -313,10 +342,11 @@ GEM
 
 PLATFORMS
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-linux-gnu
 
 DEPENDENCIES
-  danger (~> 8)
+  danger
   fastlane!
   rubocop
   rubocop-performance


### PR DESCRIPTION
## Problem

Danger was locked due to an older mismatch/upgrade of Ruby versions back in #1182 which is preventing a modernization of docs / fastlane.

## Solution

Move to Danger 9 - it moves to Ruby 2.7 min and helps move things forward.