### PR TITLE
chore: prevent infinite re-loading on 'serve'

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,7 +21,7 @@ plugins:
 - search
 - mkdocs-simple-hooks:
     hooks:
-      on_pre_build: hooks:copy_generated_files
+      on_startup: hooks:copy_generated_files
 docs_dir: docs
 extra:
   fastlane_repo_base_edit_uri: https://github.com/fastlane/fastlane/edit/master/fastlane/lib/fastlane


### PR DESCRIPTION
## Problem

When you run `mkdocs serve` it watches. Then we have `hooks: on-pre-build`. So file watcher notices a change and starts compilation, but prior runs `on-pre-build` which changes a file, which causes file watcher to go again. Infinite loop.

## Solution
Compiled files can ONLY be changed via fastlane/fastlane releases, so we can move to `on_startup` (single time). No one is modifying compiled files (or should be) and if they need do. Just re-spawn the worker. This will prevent the infinite compilation loop when working locally.