### PR TITLE
docs: Ruby 3 is min now

### DIFF
--- a/docs/includes/installing-fastlane.md
+++ b/docs/includes/installing-fastlane.md
@@ -6,7 +6,7 @@ _fastlane_ can be installed in multiple ways. The preferred method is with [_Bun
 
 If you use macOS, system Ruby is not recommended. [There are a variety of ways to install Ruby without having to modify your system environment](https://www.ruby-lang.org/en/documentation/installation/#managers). For macOS and Linux, _rbenv_ is one of the most popular ways to manage your Ruby environment.
 
-_fastlane_ supports Ruby versions 2.7 or newer, but prefers Ruby 3.3 or greater. Verify which Ruby version you're using:
+_fastlane_ supports Ruby versions 3.0 or newer, but prefers Ruby 3.3 or greater. Verify which Ruby version you're using:
 
 ```sh
 $ ruby --version


### PR DESCRIPTION
As of fastlane 2.235.0 - Ruby 3 is our min - https://github.com/fastlane/fastlane/releases/tag/2.235.0