### PR TITLE
chore: install uv via pip

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [build]
-command = "curl -LsSf https://astral.sh/uv/install.sh | sh; uv sync; uv run mkdocs build"
+command = "pip install uv; uv sync; uv run mkdocs build"
 publish = "site/"
 environment = { PYTHON_VERSION = "3.8.13" }


### PR DESCRIPTION
## Problem

It's a bit insecure to CURL and then just shell a random online file. 

## Solution

I believe we can trust Astral, but more secure until Netlify natively supports "uv" we can use pip to install uv like recommended here - https://docs.astral.sh/uv/getting-started/installation/#pypi